### PR TITLE
 ヒーロー位置・コピー間隔・リスト中央寄せ・CTA統一＆背景画像の確実な表示

### DIFF
--- a/app/assets/stylesheets/landing.css
+++ b/app/assets/stylesheets/landing.css
@@ -1,4 +1,4 @@
-/* app/assets/stylesheets/landing.css */
+/* app/assets/stylesheets/landing.scss */
 
 /* ===== Hero（トップページ） ===== */
 @layer components {
@@ -9,7 +9,7 @@
 
   .hero-top { @apply absolute inset-0 bg-gradient-to-b from-black/20 via-black/5 to-transparent; }
 
-  /* @apply では表現しづらい中央ハイライト */
+  /* 中央ハイライト（@apply では表現しづらいので生CSS） */
   .hero-center {
     position: absolute; inset: 0;
     background: radial-gradient(circle at center,
@@ -18,50 +18,52 @@
       rgba(255,255,255,0) 75%);
   }
 
-  .hero-title { @apply select-none absolute top-6 md:top-10 left-1/2 -translate-x-1/2 z-20
-                        text-white text-5xl md:text-6xl lg:text-7xl font-extrabold tracking-wide
-                        drop-shadow-[0_6px_12px_rgba(0,0,0,0.5)]; }
+  /* fasty をさらに上へ（被り解消） */
+  .hero-title {
+    @apply select-none absolute top-2 md:top-4 left-1/2 -translate-x-1/2 z-20
+           text-white text-4xl md:text-5xl lg:text-6xl font-extrabold tracking-wide
+           drop-shadow-[0_6px_12px_rgba(0,0,0,0.5)];
+  }
 
-  .hero-box  { @apply relative z-10 w-full mx-auto max-w-[1100px] px-6 text-center text-gray-900; }
-  .hero-copy { @apply mt-24 md:mt-28 lg:mt-32 text-2xl md:text-3xl lg:text-4xl font-extrabold leading-tight; }
-  .hero-list { @apply mt-6 space-y-3 text-xl md:text-2xl lg:text-3xl font-bold; }
+  .hero-box  { @apply relative z-10 w-full mx-auto max-w-[960px] px-6 text-center text-gray-900; }
+
+  /* ロゴとの間隔を広めに／全体をワンサイズ控えめに */
+  .hero-copy { @apply mt-16 sm:mt-20 text-xl md:text-2xl font-extrabold leading-snug; }
+  .hero-list { @apply mt-4 space-y-2 text-lg md:text-xl font-bold text-center; }
 
   /* CTAボタンの並び */
-  .hero-cta { @apply mt-10 flex flex-wrap items-center justify-center gap-6; }
+  .hero-cta  { @apply mt-6 flex flex-wrap items-center justify-center gap-4; }
 
-  /* ランディング専用ミントのボタン */
-  .btn-mint     { @apply inline-flex items-center justify-center rounded-full px-5 py-4 md:py-4 font-bold text-white shadow-lg; background:#2bd4c3; }
-  .btn-mint--lg { @apply w-[220px] md:w-[280px] lg:w-[320px] text-2xl md:text-3xl lg:text-4xl; }
+  /* ミント色ボタン（ランディング専用） */
+  .btn-mint     { @apply inline-flex items-center justify-center rounded-full px-5 py-3 md:py-3 font-bold text-white; background:#2bd4c3; }
+  .btn-mint--lg { @apply w-[180px] md:w-[220px] lg:w-[320px] text-lg md:text-xl lg:text-2xl; }
 }
 
-/* ===== 共通ボタン（MyPageや各画面で使用）===== */
+/* ===== 共通ボタン（Tailwind版 btn/btn-primary 相当） ===== */
 @layer components {
   .btn {
-    @apply inline-flex items-center justify-center
+    @apply inline-flex items-center justify-center font-semibold
            rounded-3xl shadow-2xl transition-all duration-200
-           font-semibold leading-tight tracking-wide
-           align-middle whitespace-nowrap
            focus-visible:outline-none focus-visible:ring-4
            disabled:opacity-50 disabled:cursor-not-allowed;
   }
-
   .btn-cta {
     @apply w-full max-w-4xl
            py-10 sm:py-12 px-16 sm:px-20
            text-3xl sm:text-4xl font-extrabold tracking-wide;
   }
-
   .btn-primary { @apply text-white bg-emerald-600 hover:bg-emerald-700 focus-visible:ring-emerald-200/70; }
   .btn-danger  { @apply text-white bg-rose-600    hover:bg-rose-700    focus-visible:ring-rose-200/70; }
 }
 
-/* ===== Utilities（細かなユーティリティ） ===== */
+/* ===== Utilities ===== */
 @layer utilities {
-  .btn-mint { transition: transform .15s ease, box-shadow .15s ease; box-shadow: 0 10px 30px rgba(43,212,195,.35); }
+  .btn-mint       { transition: transform .15s ease, box-shadow .15s ease; box-shadow: 0 10px 30px rgba(43,212,195,.35); }
   .btn-mint:hover { transform: translateY(-1.5px); box-shadow: 0 14px 34px rgba(43,212,195,.45); }
+  .btn-cta:active { transform: scale(0.99); }
 
   /* ヘッダーのブランド色（スクショに近いグレー） */
-  .bg-brand-header { background-color: #bdb6b2; }
+  .bg-brand-header        { background-color: #bdb6b2; }
   .bg-brand-header--light { background-color: #c4bdbb; }
   .bg-brand-header--dark  { background-color: #a9a3a0; }
 }
@@ -79,50 +81,44 @@
 
 /* ===== Auth（ログイン/登録/パスワード再設定） ===== */
 @layer components {
-  .auth-bg {
-    @apply relative min-h-[100svh] bg-center bg-cover bg-no-repeat;
-    background-image: image-url("landing/hero.jpg");
-  }
-  .auth-dim    { @apply absolute inset-0 bg-black/30; }
+  .auth-bg { @apply relative min-h-[100svh] bg-center bg-cover bg-no-repeat; background-image: image-url("landing/hero.jpg"); }
+  .auth-dim { @apply absolute inset-0 bg-black/30; }
   .auth-center { @apply relative min-h-[100svh] flex items-center justify-center p-4 sm:p-6 md:p-10; }
-
-  .auth-card {
-    @apply w-full max-w-[680px] md:max-w-[720px]
-           rounded-2xl bg-white/65 backdrop-blur-md
-           shadow-2xl ring-1 ring-black/10
-           p-6 md:p-8 lg:p-10
-           bg-gradient-to-b from-white/80 to-white/55
-           border border-white/50;
-  }
-  .auth-title {
-    font-size: clamp(1.5rem, 3.5vw, 2.25rem);
-    line-height: 1.2;
-    letter-spacing: 0.02em;
-  }
+  .auth-card { @apply w-full max-w-[680px] md:max-w-[720px] rounded-2xl bg-white/65 backdrop-blur-md shadow-2xl ring-1 ring-black/10 p-6 md:p-8 lg:p-10 bg-gradient-to-b from-white/80 to-white/55 border border-white/50; }
+  .auth-title { font-size: clamp(1.5rem, 3.5vw, 2.25rem); line-height: 1.2; letter-spacing: 0.02em; }
   .devise-links { @apply mt-6 text-center space-y-2; }
   .devise-links a { @apply text-blue-600 hover:text-blue-700 underline underline-offset-4; }
 }
 
-/* ===== MyPage（背景は白でOK） ===== */
+/* ===== MyPage：やさしいグラデ背景（※マイページだけに適用） ===== */
 @layer components {
-  .mypage-bg { @apply relative bg-white; }
+  .mypage-bg { position: relative; min-height: 100svh; }
+  .mypage-bg::before {
+    content: ""; position: fixed; inset: 0; z-index: -1;
+    background:
+      radial-gradient(1100px 520px at 50% 0%, rgba(59,130,246,0.06) 0%, rgba(59,130,246,0.00) 55%),
+      linear-gradient(180deg, #fafafa 0%, #f7f5f2 60%, #f4f1ed 100%);
+  }
 }
 
-/* ===== Landing (home) 追加（必要なら使う） ===== */
+/* ===== Landing (home)：トップは野菜画像（上までピタッと） ===== */
 @layer components {
-  /* 背景画像を上までピタッと */
   .landing-bg {
     @apply bg-center bg-cover bg-no-repeat;
     background-image: image-url("landing/hero.jpg");
+    background-size: cover; background-position: center; background-repeat: no-repeat;
   }
 
-  /* 少しコンパクトなヒーロー */
   .home-hero       { @apply min-h-[72svh] sm:min-h-[68svh] relative; }
   .home-hero-title { @apply text-4xl md:text-5xl lg:text-6xl; }
   .home-hero-copy  { @apply text-xl md:text-2xl leading-snug; }
   .home-hero-list  { @apply mt-4 space-y-2 text-lg md:text-xl; }
   .home-hero-cta   { @apply mt-8 flex flex-wrap items-center justify-center gap-4 md:gap-6; }
 
-  /* 小さめのピル型CTA */
   .btn-cta-sm { @apply rounded-full w-[200px] md:w-[220px] px-6 py-4 text-xl md:text-2xl; }
+}
+
+/* （任意）フラッシュ後にヒーローを少し上げたい時用 */
+@layer utilities {
+  .landing-root > .pull-up-after-flash { @apply -mt-4 sm:-mt-6; }
 }

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -6,24 +6,29 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <!-- Tailwind（既存） -->
-    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <!-- importmap & エントリ（Turbo/Stimulus 起動） -->
+    <%= javascript_importmap_tags %>
+    <%= javascript_import_module_tag "application", "data-turbo-track": "reload" %>
 
-    <!-- 必要なら Bootstrap の CSS（JS は不要） -->
+    <!-- Bootstrap は Devise画面だけに読み込む（CSSのみでOK） -->
     <link
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      data-turbo-track="reload"
     />
+
+    <!-- Tailwind / app CSS（Bootstrapの後に置く） -->
+    <%= stylesheet_link_tag "tailwind", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+
+    <%= yield :head %>
   </head>
 
   <body class="text-gray-900">
     <%= render "shared/header" %>
 
-    <div
-      class="auth-bg bg-fixed auto-top-35"
-      style="background-image: url('<%= asset_path("landing/hero.jpg") %>')"
-    >
+    <div class="auth-bg bg-fixed auto-top-35"
+         style="background-image: url('<%= asset_path("landing/hero.jpg") %>')">
       <div class="auth-dim"></div>
 
       <main class="auth-center">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,40 +1,38 @@
-<%# ===== Hero：全画面＋中央配置 ===== %>
-<% signup_url = defined?(new_user_registration_path) ? new_user_registration_path : "#" %>
-<% login_url  = defined?(new_user_session_path)      ? new_user_session_path      : "#" %>
+<%# app/views/pages/home.html.erb （トップページ） %>
 
-<section class="relative">
-  <div
-    class="hero"
-    style="background-image:url('<%= asset_path('landing/hero.jpg') %>')"
-  >
-    <div class="hero-dim"></div>
-    <div class="hero-top"></div>
-    <div class="hero-center"></div>
+<div class="hero"
+     style="background-image: url('<%= asset_path("landing/hero.jpg") %>');
+            background-size: cover;
+            background-position: center;
+            background-repeat: no-repeat;">
 
-    <!-- タイトル（上部中央） -->
-    <h1 class="hero-title">fasty</h1>
+  <!-- オーバーレイ（薄く白＋グラデーション） -->
+  <div class="hero-dim"></div>
+  <div class="hero-top"></div>
+  <div class="hero-center"></div>
 
-    <!-- 中央コンテンツ -->
-    <div class="hero-box">
-      <!-- ベネフィットを端的に -->
-      <p class="hero-copy">
-        毎日つづく、やさしいファスティング。<br>内側から“きれい”を育てよう。
-      </p>
+  <div class="hero-box">
+    <!-- タイトル：さらに上へ配置 -->
+    <h1 class="hero-title !top-1 sm:!top-2 md:!top-3">fasty</h1>
 
-      <!-- 習慣化に効く要素だけを箇条書き -->
-      <ul class="hero-list">
-        <li>✅ 目標時間に合わせて無理なく継続</li>
-        <li>✅ 成功も失敗もワンタップで記録</li>
-      </ul>
+    <!-- キャッチコピー：ワンサイズ控えめ／余白少なめ -->
+    <p class="hero-copy mt-20 sm:mt-24 md:mt-28">
+      毎日つづく、やさしいファスティング。<br>
+      内側から“きれい”を育てよう。
+    </p>
 
-      <!-- CTA：プライマリは登録／ログインは控えめ -->
-      <div class="mt-8 grid grid-cols-1 sm:grid-cols-2 gap-6 justify-items-center">
-        <%= link_to "新規登録", signup_url,
-              class: "btn-mint btn-mint--lg" %>
+    <!-- チェックリスト（中央寄せ／余白調整） -->
+    <ul class="hero-list text-center mt-6">
+      <li>✅ 目標時間に合わせて無理なく継続</li>
+      <li>✅ 成功も失敗もワンタップで記録</li>
+    </ul>
 
-        <%= link_to "ログイン", login_url,
-              class: "btn-mint btn-mint--lg" %>
-      </div>
+    <!-- CTAボタン（新規登録・ログインを同じデザインで並列） -->
+    <div class="hero-cta mt-8">
+      <%= link_to "新規登録", new_user_registration_path,
+                  class: "btn-mint btn-mint--lg" %>
+      <%= link_to "ログイン", new_user_session_path,
+                  class: "btn-mint btn-mint--lg" %>
     </div>
   </div>
-</section>
+</div>


### PR DESCRIPTION
## 目的
トップのヒーロー体験を整理し、第一印象と CV 導線を改善する。

## 変更点（What）
- ヒーロータイトルを「画面上部付近」へ上寄せ
- キャッチコピーの行間・サイズを最適化
- チェックリストを中央寄せ
- CTA（新規登録／ログイン）をピル型で統一
- 背景画像の表示を安定化（`cover`/`center`、薄い白レイヤーでコントラスト確保）
- `landing.css` に共通ボタン／utilities を整理
- `devise.html.erb` / `pages/home.html.erb` のスタイル参照を調整

## スクショ
- **未ログインのトップ**：SP/PC それぞれ 1 枚（合計 2 枚）
  - タイトル上寄せ／リスト中央寄せ／CTA 統一が分かる構図で

## 動作確認
- 画像が途切れず `cover/center` で表示される
- タイトルが上寄せ、チェックリストが中央寄せ
- CTA が横並び（幅が狭い場合は自然に縦積み）
- フッターは 1 画面に収まる（`main.grow` 継承）


## 影響範囲 / 互換性
- 影響：`pages#home`（未ログインのランディング）および認証レイアウトの見た目のみ
- `/mypage` や記録一覧の挙動には影響なし

## リスク / ロールバック
- 万一問題が出た場合はこの PR のリバートで即時復旧可能

## 関連
- Epic: #18

## チェックリスト
- [x] `bundle exec rubocop` OK（41 files inspected, no offenses）
- [x] `bin/rails tailwindcss:build` OK
- [ ] スクショ添付（SP/PC）
<img width="487" height="76" alt="スクリーンショット 2025-08-26 19 44 33" src="https://github.com/user-attachments/assets/5fe81c11-1831-4986-8241-097388a9e101" />
<img width="499" height="95" alt="スクリーンショット 2025-08-26 19 44 18" src="https://github.com/user-attachments/assets/00bf8c48-476b-477a-a77c-86f9cf2e43fc" />
<img width="1299" height="670" alt="スクリーンショット 2025-08-26 19 46 00" src="https://github.com/user-attachments/assets/ea96f938-fc0a-42fe-bb04-e0b695a382fb" />
