### PR TITLE
依存Gemの更新（アプリ本体の差分なし）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 ruby "3.2.2"
 gem "tailwindcss-rails"
+gem "kaminari"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.2.2", ">= 7.2.2.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,18 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.13.2)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
@@ -311,6 +323,7 @@ DEPENDENCIES
   debug
   devise (~> 4.9)
   importmap-rails
+  kaminari
   mysql2 (~> 0.5)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)


### PR DESCRIPTION
目的
- 依存 Gem を最新化してセキュリティ修正と不具合修正を取り込みます。

変更点
- `Gemfile` / `Gemfile.lock` のみ変更
- アプリコードやフロント資産の変更はありません

確認
- docker compose build / bundle install OK
- bundle exec rubocop OK
- bin/rails tailwindcss:build OK

影響
- 目立った breaking change なし（Rails 7.2 系のパッチ更新）
- マージ後は念のため `docker compose build web` を一度実行してください
