### PR TITLE
actions/checkout を v5 に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   lint:                      # CI / lint (pull_request)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2.2'
@@ -29,7 +29,7 @@ jobs:
   scan_ruby:                 # CI / scan_ruby (pull_request)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2.2'


### PR DESCRIPTION
目的: GitHub Actions の actions/checkout を v5 に更新し、最新ランナー(Node 20)ベースに追従します。

変更点: .github/workflows/* の actions/checkout@v4 → @v5 へ置換のみ。

影響範囲: CI（GitHub Actions）のみ。アプリコード・フロント資産の変更なし。

動作確認: PR 作成後の CI で成功を確認予定。

参考: v5 は Node 20 ベース。今回のワークフローでは互換性問題はありません。