### PR TITLE
fix: datetime-localのstep不一致で保存できない問題を修正（秒を許可・自動入力を秒付きに）

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,4 +7,10 @@ module ApplicationHelper
     def home_path
         user_signed_in? ? authenticated_root_path : unauthenticated_root_path
     end
+
+    # datetime-local 用（タイムゾーン無しの "YYYY-MM-DDTHH:MM:SS"）
+    def datetime_local_value(time)
+    return "" if time.blank?
+    time.in_time_zone.strftime("%Y-%m-%dT%H:%M:%S")
+  end
 end

--- a/app/javascript/controllers/fasting_form_controller.js
+++ b/app/javascript/controllers/fasting_form_controller.js
@@ -3,22 +3,37 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["start", "targetHours", "end"]
 
-  connect() { this.updateEnd() }
+  connect() {
+    // 念のため JS 側でも step を 1 に（HTML側でも step: 1 を付けてね）
+    this.startTarget?.setAttribute("step", "1")
+    this.endTarget?.setAttribute("step", "1")
+    this.updateEnd()
+  }
 
   updateEnd() {
     const startStr = this.startTarget.value
     const hours = parseInt(this.targetHoursTarget.value, 10)
+
     if (!startStr || Number.isNaN(hours)) {
-        this.endTarget.value = ""
-        return
+      this.endTarget.value = ""
+      return
     }
 
-    const start = new Date(startStr) // datetime-local はローカル時刻
+    // datetime-local はローカル時刻として解釈される
+    const start = new Date(startStr)
     if (Number.isNaN(start.getTime())) return
 
     const end = new Date(start.getTime() + hours * 3600 * 1000)
+
     const pad = n => String(n).padStart(2, "0")
-    const endLocal = `${end.getFullYear()}-${pad(end.getMonth()+1)}-${pad(end.getDate())}T${pad(end.getHours())}:${pad(end.getMinutes())}`
+    // ★ 秒まで含める（YYYY-MM-DDTHH:MM:SS）
+    const endLocal =
+      `${end.getFullYear()}-${pad(end.getMonth() + 1)}-${pad(end.getDate())}` +
+      `T${pad(end.getHours())}:${pad(end.getMinutes())}:${pad(end.getSeconds())}`
+
     this.endTarget.value = endLocal
+
+    // 任意: 開始より前を禁止したい場合
+    // this.endTarget.min = this.startTarget.value
   }
 }

--- a/app/views/fasting_records/_form.html.erb
+++ b/app/views/fasting_records/_form.html.erb
@@ -10,13 +10,18 @@
 
   <div>
     <label class="block text-sm text-gray-600">開始</label>
-    <%= f.datetime_field :start_time,
+    <%= f.datetime_local_field :start_time,
+          value:  datetime_local_value(@record.start_time || Time.current),
+          step:   1,
           data: { "fasting-form-target": "start", action: "input->fasting-form#updateEnd change->fasting-form#updateEnd" } %>
   </div>
 
   <div>
     <label class="block text-sm text-gray-600">終了（必須・自動入力）</label>
-    <%= f.datetime_field :end_time, required: true,
+    <%= f.datetime_local_field :end_time,
+          value:  datetime_local_value(@record.end_time || Time.current),
+          step:   1,
+          required: true,
           data: { "fasting-form-target": "end" } %>
   </div>
 


### PR DESCRIPTION
## 概要
editフォームで「終了」の自動入力後に HTML5 検証で弾かれて保存できない不具合を修正。

## 原因
`datetime-local` の分解能が 60 秒相当のまま（step未指定）で、値/最小値の“秒”がズレると不正扱いになるため。

## 対応
- フィールドを `datetime_local_field` に変更し、`step: 1` を付与
- 自動入力（Stimulus）を `YYYY-MM-DDTHH:MM:SS` 形式でセット
- ヘルパー `datetime_local_value` を追加して秒付きフォーマットを安定供給

## 動作確認
1. 「開始」→「終了する」→編集画面のまま保存が通る
2. 秒が `:00` / `:29` などでも保存可能
3. 目標時間を変更→終了時刻が自動再計算される
