### PR TITLE
chore: 手動選択の案内テキストを削除（結果は自動判定に統一）

### DIFF
--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -31,7 +31,6 @@
             class="font-mono text-2xl sm:text-3xl align-middle">00:00:00</span>
         </div>
         <div class="text-sm text-gray-600">開始：<%= l @running.start_time %></div>
-        <p class="text-xs text-gray-500">※ 終了後に「達成/失敗」は編集画面で選択します</p>
         <div class="text-right">
           <%= link_to "記録一覧へ", fasting_records_path, class: "text-blue-600 underline text-sm" %>
         </div>


### PR DESCRIPTION
## 概要
結果が自動判定に変更されたため、旧仕様の案内文を削除します。

## 変更点
- `app/views/mypages/show.html.erb`: 「※ 終了後に『達成/失敗』は編集画面で選択します」の1行を削除

## 影響範囲・リスク
- 画面表示の文言のみ。ロジック変更なし／副作用なし。

## 動作確認
- マイページを表示して、当該文言が表示されないこと
- 他画面にも同様の文言が残っていないこと（`git grep -n '編集画面で選択'` で0件）
<img width="1172" height="616" alt="スクリーンショット 2025-09-11 17 34 31" src="https://github.com/user-attachments/assets/1cff599e-6a8e-46c3-87a0-ffc1c91b6273" />
