### PR TITLE
feat: 瞑想ガイドの外部リンク（5/10/20/30分）を追加（YAML管理・一覧）

### DIFF
--- a/app/controllers/meditations_controller.rb
+++ b/app/controllers/meditations_controller.rb
@@ -1,0 +1,14 @@
+class MeditationsController < ApplicationController
+  before_action :authenticate_user!  # ログイン後に見る想定なら
+
+  def index
+    path = Rails.root.join("config/meditations.yml")
+    raw  = YAML.safe_load_file(path, aliases: false) rescue []
+    @meditations = Array(raw).map { |m|
+      { title: m["title"].to_s,
+        url: m["url"].to_s,
+        duration_min: m["duration_min"].to_i,
+        tags: Array(m["tags"]).map(&:to_s) }
+    }.sort_by { |m| m[:duration_min] }
+  end
+end

--- a/app/views/meditations/index.html.erb
+++ b/app/views/meditations/index.html.erb
@@ -1,0 +1,24 @@
+<div class="mx-auto max-w-4xl p-4">
+  <h1 class="text-xl font-semibold">瞑想ガイド（5分/ 10分/ 20分 / 30分）</h1>
+  <div class="mt-4 grid gap-4 sm:grid-cols-2">
+    <% @meditations.each do |m| %>
+      <article class="rounded-xl border bg-white p-4">
+        <div class="flex items-start justify-between">
+          <h2 class="font-medium"><%= m[:title] %></h2>
+          <span class="text-[11px] px-2 py-0.5 rounded bg-stone-100"><%= m[:duration_min] %>分</span>
+        </div>
+        <% if m[:tags].present? %>
+          <div class="mt-2 flex flex-wrap gap-1">
+            <% m[:tags].each do |t| %>
+              <span class="text-[11px] px-2 py-0.5 rounded bg-emerald-50 text-emerald-700">#<%= t %></span>
+            <% end %>
+          </div>
+        <% end %>
+        <div class="mt-3">
+          <%= link_to "瞑想を始める", m[:url], target: "_blank", rel: "noopener",
+              class: "inline-block text-sm underline hover:opacity-80" %>
+        </div>
+      </article>
+    <% end %>
+  </div>
+</div>

--- a/config/meditations.yml
+++ b/config/meditations.yml
@@ -1,0 +1,20 @@
+# TODO: 実運用時はあなたが選んだガイドに置き換えてください（再配布せずリンクのみ）
+- title: "[初めての瞑想 5分] 寝たまま5分間で心も体もスッキリ!!"
+  url: "https://youtu.be/Wx4d1B-Wniw?si=c6sYE0XucisXty7E"
+  duration_min: 5
+  tags: [短時間, すぐ始める]
+
+- title: "[初めての瞑想 10分] 毎日10分間で自己肯定感と集中力を高める瞑想"
+  url: "https://youtu.be/kg5L2aIMOHg?si=lio9Zg7viA5H5JXT"
+  duration_min: 10
+  tags: [集中, リセット]
+
+- title: "[寝る前の瞑想 20分] 20分カンタン瞑想『ヨガ二ドラ(眠りのヨガ)』"
+  url: "https://youtu.be/58bmqCgJWJ4?si=Gk-GaGMH2yKtx1un"
+  duration_min: 20
+  tags: [夜, じっくり]
+
+- title: "[感謝の瞑想 30分] 1日30分で幸福感と感謝力を高めるマインドフルネス瞑想"
+  url: "https://youtu.be/Mt0ffj8u5uw?si=ooBvQPxRkM_FSsdp"
+  duration_min: 30
+  tags: [休日, 感謝, 深呼吸]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,8 +23,11 @@ Rails.application.routes.draw do
     post :finish, on: :member       # POST /fasting_records/:id/finish
   end
 
+  # --- 瞑想リンク（MVPは外部リンク一覧のみ） ---
+  resources :meditations, only: :index
+
   # --- ヘルスチェック / PWA ---
   get "up" => "rails/health#show", as: :rails_health_check
-  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+  get "service-worker.js" => "rails/pwa#service_worker", as: :pwa_service_worker
+  get "manifest.json"     => "rails/pwa#manifest",       as: :pwa_manifest
 end


### PR DESCRIPTION
断食中の離脱を防ぎ“気持ちを整える”ため、瞑想ガイドを 5/10/20/30 分の外部リンクで提供

データは config/meditations.yml 管理（差し替え容易）

/meditations にカード表示・新規タブで開く

MVPはリンクのみ（埋め込みは後続）