### PR TITLE
ui: 記録一覧で経過時間を併記（達成/失敗/進行中に (X時間Y分) 表示）

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,4 +32,21 @@ module ApplicationHelper
 
     link_to name, href, { class: classes, "aria-current": (active ? "page" : nil) }.merge(opts)
   end
+
+  # 秒 → "X時間Y分"（Y=0なら省略）。nilなら "−"
+  def human_duration(seconds, blank: "-")
+    return blank if seconds.nil?
+
+    total = seconds.to_i.abs
+    h = total / 3600
+    m = (total % 3600) / 60
+
+    if h.positive? && m.positive?
+      "#{h}時間#{m}分"
+    elsif h.positive?
+      "#{h}時間"
+    else
+      "#{m}分"
+    end
+  end
 end

--- a/app/views/fasting_records/index.html.erb
+++ b/app/views/fasting_records/index.html.erb
@@ -50,11 +50,24 @@
         </thead>
         <tbody>
         <% @records.each do |r| %>
+          <%# --- 結果ラベル（達成/失敗/進行中） + 所要時間の生成 --- %>
+          <% dur = r.duration_seconds.to_i %>
+          <% h   = dur / 3600
+             m   = (dur % 3600) / 60
+             dur_text = [("#{h}時間" if h.positive?), ("#{m}分" if m.positive?)].compact.join %>
+          <% result_text =
+               if r.end_time.nil?
+                 "進行中（#{dur_text}）"
+               else
+                 base = r.success.nil? ? "" : (r.success ? "達成" : "失敗")
+                 base.present? ? "#{base}（#{dur_text}）" : dur_text
+               end %>
+
           <tr class="border-t">
             <td class="px-3 py-2"><%= fmt_jp(r.start_time) %></td>
             <td class="px-3 py-2"><%= fmt_jp(r.end_time) %></td>
             <td class="px-3 py-2 text-center"><%= r.target_hours || "-" %></td>
-            <td class="px-3 py-2"><%= r.success.nil? ? "-" : (r.success ? "達成" : "失敗") %></td>
+            <td class="px-3 py-2"><%= result_text %></td>
             <td class="px-3 py-2">
               <%= link_to "詳細", r, class: "text-blue-600 underline" %>
               <span class="text-gray-300 mx-1">/</span>


### PR DESCRIPTION
## 目的
結果の「達成/失敗」だけでは分からない断食時間を一覧で一目把握できるようにするため。

## 変更
- helper `human_duration(seconds)` を追加（"X時間Y分" 表示）
- 一覧の結果列に `(X時間Y分)` を併記。進行中は「進行中 (X時間Y分)」

## 動作確認
- 進行中：現在時刻からの経過を分単位～で表示
- 終了済み：達成/失敗のラベルに時間を併記
<img width="1282" height="666" alt="スクリーンショット 2025-09-13 15 06 20" src="https://github.com/user-attachments/assets/e1cf2c05-38fd-4cf2-b62f-a3a304c0df22" />
<img width="1211" height="653" alt="スクリーンショット 2025-09-13 15 19 14" src="https://github.com/user-attachments/assets/4fe8b0c1-dc50-422f-84d0-5992e8664750" />
