### PR TITLE
記録一覧をサマリー表示に刷新（日時＋合計時間＋コメント）／フィルタ強化・スタイル整備

### DIFF
--- a/app/assets/stylesheets/landing.css
+++ b/app/assets/stylesheets/landing.css
@@ -22,7 +22,7 @@
     pointer-events: none;
 
     /* レイアウトから渡す CSS 変数が無い場合のフォールバックも用意 */
-    background-image: var(--hero-bg, image-url("landing/hero.jpg"));
+    background-image: var(--hero-bg, url("/assets/landing/hero.jpg"));
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
@@ -133,7 +133,7 @@
 
 /* ===== Auth（ログイン等） ===== */
 @layer components {
-  .auth-bg { @apply relative min-h-[100svh] bg-center bg-cover bg-no-repeat; background-image: image-url("landing/hero.jpg"); }
+  .auth-bg { @apply relative min-h-[100svh] bg-center bg-cover bg-no-repeat; background-image: var(--hero-bg, url("/assets/landing/hero.jpg")); }
   .auth-dim { @apply absolute inset-0 bg-black/30; }
   .auth-center { @apply relative min-h-[100svh] flex items-center justify-center p-4 sm:p-6 md:p-10; }
   .auth-card { @apply w-full max-w-[680px] md:max-w-[720px] rounded-2xl bg-white/65 backdrop-blur-md shadow-2xl ring-1 ring-black/10 p-6 md:p-8 lg:p-10 bg-gradient-to-b from-white/80 to-white/55 border border-white/50; }
@@ -157,7 +157,7 @@
 @layer components {
   .landing-bg {
     @apply bg-center bg-cover bg-no-repeat;
-    background-image: image-url("landing/hero.jpg");
+    background-image: var(--hero-bg, url("/assets/landing/hero.jpg"));
   }
   .home-hero       { @apply min-h-[72svh] sm:min-h-[68svh] relative; }
   .home-hero-title { @apply text-4xl md:text-5xl lg:text-6xl; }
@@ -203,10 +203,29 @@
     display: block;
   }
 }
+@layer components {
+  /* アイコン内テキストが省略記号に潰れないようガード */
+  .icon-btn, .icon-btn * {
+    text-overflow: clip !important;
+    overflow: visible !important;
+    white-space: normal !important;
+  }
+ }
 
-/* アイコン内テキストが省略記号に潰れないようガード */
-.icon-btn, .icon-btn * {
-  text-overflow: clip !important;
-  overflow: visible !important;
-  white-space: normal !important;
+
+/* === Fasting Records: badges & comment snippet === */
+@layer components {
+  .badge { @apply inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold ring-1; }
+  .badge--ok   { @apply bg-emerald-100 text-emerald-800 ring-emerald-200; }
+  .badge--ng   { @apply bg-rose-100 text-rose-800 ring-rose-200; }
+  .badge--info { @apply bg-indigo-100 text-indigo-800 ring-indigo-200; }
+
+  /* コメントは2行で省略（プラグイン無し運用） */
+  .record-comment {
+    @apply text-sm text-gray-600 mt-0.5;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
 }

--- a/app/controllers/fasting_records_controller.rb
+++ b/app/controllers/fasting_records_controller.rb
@@ -10,7 +10,7 @@ class FastingRecordsController < ApplicationController
 
     case normalize_status(params[:status])
     when "achieved"    then scope = scope.respond_to?(:achieved)    ? scope.achieved    : scope.where(success: true).where.not(end_time: nil)
-    when "unachieved"  then scope = scope.respond_to?(:unachieved)  ? scope.unachieved  : scope.where(success: [false, nil]).where.not(end_time: nil)
+    when "unachieved"  then scope = scope.respond_to?(:unachieved)  ? scope.unachieved  : scope.where(success: [ false, nil ]).where.not(end_time: nil)
     when "in_progress" then scope = scope.respond_to?(:running)     ? scope.running     : scope.where(end_time: nil)
     else
       # すべて表示

--- a/app/helpers/fasting_records_helper.rb
+++ b/app/helpers/fasting_records_helper.rb
@@ -2,10 +2,43 @@
 module FastingRecordsHelper
   WDAY_JA = %w[日 月 火 水 木 金 土].freeze
 
+  # 例: "2025/09/14(日) 14時18分"
   def fmt_jp(dt)
     return "-" if dt.blank?
-    t = dt.respond_to?(:in_time_zone) ? dt.in_time_zone : Time.zone.parse(dt.to_s)
+    t = to_time_in_zone(dt)
     t.strftime("%Y/%m/%d(#{WDAY_JA[t.wday]}) %H時%M分")
+  end
+
+  # 一覧用：日付のみ（例: "2025/09/14(日)"）
+  def list_date(dt)
+    return "-" if dt.blank?
+    t = to_time_in_zone(dt)
+    t.strftime("%Y/%m/%d(#{WDAY_JA[t.wday]})")
+  end
+
+  # バッジ（達成/未達成/進行中）
+  def status_badge(record)
+    base = "inline-flex items-center whitespace-nowrap rounded-full px-2 py-0.5 text-xs font-semibold ring-1"
+    case record.status_key
+    when :achieved
+      content_tag(:span, "達成", class: "badge badge--ok")
+    when :unachieved
+      content_tag(:span, "未達成", class: "badge badge--ng")
+    else
+      content_tag(:span, "進行中", class: "badge badge--info")
+    end
+  end
+
+  # コメントの抜粋（2行想定。CSS で line-clamp する想定）
+  def comment_snippet(record, length: 60)
+    text = record.comment_text.to_s.strip
+    return "".html_safe if text.blank?
+
+    content_tag(:div, class: "record-comment", title: text) do
+      content_tag(:span, "💬", aria: { hidden: true }) <<
+      content_tag(:span, " ") <<
+      content_tag(:span, truncate(text, length: length))
+    end
   end
 
   # 終了が開始より前/未設定なら "-" を返す、安全版
@@ -19,9 +52,15 @@ module FastingRecordsHelper
     "#{h}時間#{m}分"
   end
 
-  # 進行中の経過時間を出したいとき用（to が nil のときは現在時刻で計算）
+  # 進行中の経過時間用（to が nil のときは現在時刻で計算）
   def fmt_elapsed(from, to = nil)
     return "-" if from.blank?
     fmt_duration(from, to || Time.current)
+  end
+
+  private
+
+  def to_time_in_zone(dt)
+    dt.respond_to?(:in_time_zone) ? dt.in_time_zone : Time.zone.parse(dt.to_s)
   end
 end

--- a/app/models/fasting_record.rb
+++ b/app/models/fasting_record.rb
@@ -1,13 +1,13 @@
 class FastingRecord < ApplicationRecord
   belongs_to :user, optional: true
 
-  TARGET_HOURS_CHOICES = [12, 14, 16, 18, 20, 22, 24].freeze
+  TARGET_HOURS_CHOICES = [ 12, 14, 16, 18, 20, 22, 24 ].freeze
   GRACE_SECONDS = 30 # 判定の猶予（必要に応じて 0〜60 で調整）
 
   scope :running,  -> { where(end_time: nil) }
   scope :finished, -> { where.not(end_time: nil) }
   scope :achieved, -> { finished.where(success: true) }
-  scope :unachieved, -> { finished.where(success: [false, nil]) }
+  scope :unachieved, -> { finished.where(success: [ false, nil ]) }
 
   # 同一ユーザーで「進行中（end_time: nil）」が複数できないように
   validates :user_id, uniqueness: { conditions: -> { where(end_time: nil) } }
@@ -74,9 +74,9 @@ class FastingRecord < ApplicationRecord
 
   def elapsed_hm
     s = elapsed_seconds
-    return [0, 0] unless s
+    return [ 0, 0 ] unless s
     mins = s / 60
-    [mins / 60, mins % 60]
+    [ mins / 60, mins % 60 ]
   end
 
   # 自動判定（猶予付き）

--- a/app/models/fasting_record.rb
+++ b/app/models/fasting_record.rb
@@ -1,10 +1,13 @@
 class FastingRecord < ApplicationRecord
   belongs_to :user, optional: true
 
-  TARGET_HOURS_CHOICES = [ 12, 14, 16, 18, 20, 22, 24 ].freeze
+  TARGET_HOURS_CHOICES = [12, 14, 16, 18, 20, 22, 24].freeze
   GRACE_SECONDS = 30 # 判定の猶予（必要に応じて 0〜60 で調整）
 
-  scope :running, -> { where(end_time: nil) }
+  scope :running,  -> { where(end_time: nil) }
+  scope :finished, -> { where.not(end_time: nil) }
+  scope :achieved, -> { finished.where(success: true) }
+  scope :unachieved, -> { finished.where(success: [false, nil]) }
 
   # 同一ユーザーで「進行中（end_time: nil）」が複数できないように
   validates :user_id, uniqueness: { conditions: -> { where(end_time: nil) } }
@@ -19,14 +22,61 @@ class FastingRecord < ApplicationRecord
   before_validation :auto_set_success,
                     if: -> { start_time.present? && end_time.present? && target_hours.present? }
 
+  # ====== 一覧/表示用ユーティリティ ======
+
+  # 進行中か？
   def running?
     end_time.nil?
   end
 
-  # 開始〜終了の秒数（両方あるときのみ）
+  # 成功・未達成・進行中のキー（ビューのバッジ分岐用）
+  # :achieved / :unachieved / :in_progress
+  def status_key
+    return :in_progress if running?
+    success? ? :achieved : :unachieved
+  end
+
+  # 一覧に出す日付（終了があれば終了日、なければ開始日）
+  def date_for_list
+    (end_time || start_time)&.in_time_zone&.to_date
+  end
+
+  # 一覧の「ファスティング⌛️xx時間yy分」に使う表示用の経過時間
+  # 進行中は現在時刻までで算出、終了済みは start..end
+  def duration_text
+    h, m = elapsed_hm
+    format("%d時間%02d分", h, m)
+  end
+
+  # 目標表示用 "xxh"
+  def target_hours_label
+    "#{target_hours}h"
+  end
+
+  # コメント（comment / note / memo のどれかを採用）
+  def comment_text
+    self[:comment].presence || self[:note].presence || self[:memo].presence
+  end
+
+  # ====== 判定/内部計算 ======
+
+  # 成否判定に使う「確定の秒数」（終了しているときのみ）
   def duration_seconds
     return nil unless start_time && end_time
     (end_time - start_time).to_i
+  end
+
+  # 表示用の経過秒（終了済みなら確定、進行中なら現在時刻まで）
+  def elapsed_seconds
+    return nil unless start_time
+    ((end_time || Time.current) - start_time).to_i
+  end
+
+  def elapsed_hm
+    s = elapsed_seconds
+    return [0, 0] unless s
+    mins = s / 60
+    [mins / 60, mins % 60]
   end
 
   # 自動判定（猶予付き）

--- a/app/views/fasting_records/index.html.erb
+++ b/app/views/fasting_records/index.html.erb
@@ -12,19 +12,29 @@
 
   <!-- フィルタ -->
   <div class="flex gap-2">
-    <% cur = params[:status].presence %>
+    <% raw_cur = params[:status].presence %>
+    <%# 旧URLの "success"/"failure" を新語に正規化して扱う %>
+    <% cur = case raw_cur when "success" then "achieved" when "failure" then "unachieved" else raw_cur end %>
+
     <%= link_to "すべて", fasting_records_path,
           class: ["px-3 py-1 rounded-md ring-1",
                   (cur.nil? ? "bg-gray-900 ring-gray-900 text-white" : "bg-white ring-gray-300 text-gray-700 hover:bg-gray-50")].join(" "),
           "aria-current": (cur.nil? ? "page" : nil) %>
-    <%= link_to "達成", fasting_records_path(status: "success"),
+
+    <%= link_to "達成", fasting_records_path(status: "achieved"),
           class: ["px-3 py-1 rounded-md ring-1",
-                  (cur == "success" ? "bg-gray-900 ring-gray-900 text-white" : "bg-white ring-gray-300 text-gray-700 hover:bg-gray-50")].join(" "),
-          "aria-current": (cur == "success" ? "page" : nil) %>
-    <%= link_to "失敗", fasting_records_path(status: "failure"),
+                  (cur == "achieved" ? "bg-gray-900 ring-gray-900 text-white" : "bg-white ring-gray-300 text-gray-700 hover:bg-gray-50")].join(" "),
+          "aria-current": (cur == "achieved" ? "page" : nil) %>
+
+    <%= link_to "未達成", fasting_records_path(status: "unachieved"),
           class: ["px-3 py-1 rounded-md ring-1",
-                  (cur == "failure" ? "bg-gray-900 ring-gray-900 text-white" : "bg-white ring-gray-300 text-gray-700 hover:bg-gray-50")].join(" "),
-          "aria-current": (cur == "failure" ? "page" : nil) %>
+                  (cur == "unachieved" ? "bg-gray-900 ring-gray-900 text-white" : "bg-white ring-gray-300 text-gray-700 hover:bg-gray-50")].join(" "),
+          "aria-current": (cur == "unachieved" ? "page" : nil) %>
+
+    <%= link_to "進行中", fasting_records_path(status: "in_progress"),
+          class: ["px-3 py-1 rounded-md ring-1",
+                  (cur == "in_progress" ? "bg-gray-900 ring-gray-900 text-white" : "bg-white ring-gray-300 text-gray-700 hover:bg-gray-50")].join(" "),
+          "aria-current": (cur == "in_progress" ? "page" : nil) %>
   </div>
 
   <% if @records.blank? %>
@@ -33,85 +43,36 @@
       <%= link_to "マイページからファスティングを開始", mypage_path, class: "text-blue-600 hover:text-blue-700 underline font-medium" %>
     </div>
   <% else %>
-    <div class="overflow-x-auto">
-      <table class="min-w-full text-sm bg-white/80 ring-1 ring-gray-200 rounded-lg overflow-hidden">
-        <thead class="bg-gray-50 text-gray-600">
-          <tr>
-            <th class="px-3 py-2 text-left font-semibold">開始</th>
-            <th class="px-3 py-2 text-left font-semibold">終了</th>
-            <th class="px-3 py-2 text-center font-semibold">目標(h)</th>
-            <th class="px-3 py-2 text-left font-semibold">結果</th>
-            <th class="px-3 py-2 text-left font-semibold">操作</th>
-          </tr>
-        </thead>
-        <tbody class="divide-y divide-gray-100">
-        <% @records.each do |r| %>
-          <% status, badge =
-               if r.end_time.nil?
-                 ["進行中", "bg-amber-100 text-amber-800 ring-amber-200"]
-               elsif r.success
-                 ["達成", "bg-emerald-100 text-emerald-800 ring-emerald-200"]
-               else
-                 ["失敗", "bg-rose-100 text-rose-800 ring-rose-200"]
-               end %>
-          <% dur_text = human_duration(r.duration_seconds, blank: "計測中") %>
+    <!-- ▼ 1行=1記録 のサマリー表示 -->
+    <div class="record-list divide-y divide-gray-100 rounded-lg ring-1 ring-gray-200 overflow-hidden bg-white/80">
+      <% @records.each do |r| %>
+        <%= link_to fasting_record_path(r),
+                    class: "record-row flex justify-between items-center px-4 py-3 hover:bg-gray-50 transition-colors",
+                    "aria-label": "#{list_date(r.date_for_list)} / ファスティング#{r.duration_text} / 目標 #{r.target_hours_label}" do %>
+          <div class="row-left flex flex-col gap-0.5">
+            <div class="record-date text-sm text-gray-600"><%= list_date(r.date_for_list) %></div>
+            <div class="record-title font-semibold">
+              ファスティング⌛️<%= r.duration_text %>
+              <% if r.running? %><span class="progress-note text-xs text-gray-500 ml-1">（計測中）</span><% end %>
+            </div>
+            <%= comment_snippet(r) %>
+          </div>
 
-          <tr>
-            <td class="px-3 py-2"><%= fmt_jp(r.start_time) %></td>
-            <td class="px-3 py-2"><%= fmt_jp(r.end_time) || "-" %></td>
-            <td class="px-3 py-2 text-center"><%= r.target_hours || "-" %></td>
-            <td class="px-3 py-2">
-              <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold ring-1 <%= badge %>">
-                <%= status %>
-              </span>
-              <span class="ml-2 text-gray-600">（<%= dur_text %>）</span>
-            </td>
-
-            <td class="px-3 py-2">
-              <div class="flex items-center gap-2">
-                <!-- 詳細 -->
-                <%= link_to r, class: "inline-flex w-9 h-9 items-center justify-center rounded-md hover:bg-black/5",
-                            title: "詳細", "aria-label": "詳細" do %>
-                  <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" fill="#374151">
-                    <path d="M12 5c-7 0-11 7-11 7s4 7 11 7 11-7 11-7-4-7-11-7zm0 12a5 5 0 1 1 0-10 5 5 0 0 1 0 10z"/>
-                    <circle cx="12" cy="12" r="3"/>
-                  </svg>
-                  <span class="sr-only">詳細</span>
-                <% end %>
-
-                <!-- 編集 -->
-                <%= link_to edit_fasting_record_path(r),
-                    class: "inline-flex w-9 h-9 items-center justify-center rounded-md hover:bg-black/5",
-                    title: "編集", "aria-label": "編集" do %>
-                  <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" fill="#2563eb">
-                    <path d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04a1 1 0 0 0 0-1.41L18.37 3.29a1 1 0 0 0-1.41 0L15.13 5.1l3.75 3.75 1.83-1.81z"/>
-                  </svg>
-                  <span class="sr-only">編集</span>
-                <% end %>
-
-                <!-- 削除 -->
-                <%= button_to fasting_record_path(r),
-                    method: :delete,
-                    form: { class: "inline" },
-                    data: { turbo_confirm: "本当に削除しますか？" },
-                    class: "inline-flex w-9 h-9 items-center justify-center rounded-md hover:bg-black/5",
-                    title: "削除", "aria-label": "削除" do %>
-                  <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true" fill="#e11d48">
-                    <path d="M6 19a2 2 0 0 0 2 2h8a2 2 0 0 0 2-2V7H6v12zm3.5-9h1.5v8H9.5v-8zm5 0h1.5v8h-1.5v-8zM15.5 4l-1-1h-5l-1 1H5v2h14V4h-3.5z"/>
-                  </svg>
-                  <span class="sr-only">削除</span>
-                <% end %>
-              </div>
-            </td>
-          </tr>
+          <div class="row-right flex items-center gap-3">
+            <div class="record-goal text-sm text-gray-700">目標 <%= r.target_hours_label %></div>
+            <div class="record-status whitespace-nowrap"><%= status_badge(r) %></div>
+            <!-- 右端のナビアイコン -->
+            <svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 111.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+            </svg>
+          </div>
         <% end %>
-        </tbody>
-      </table>
+      <% end %>
     </div>
 
     <% if defined?(Kaminari) && @records.respond_to?(:current_page) %>
       <div class="mt-6">
-        <%= paginate @records %>
+        <%= paginate @records, params: { status: params[:status] } %>
       </div>
     <% end %>
   <% end %>


### PR DESCRIPTION
概要

記録一覧を「日付＋ファスティング⌛️合計時間＋コメント抜粋」の1行=1記録に刷新し、視認性を向上。

目標時間と達成可否は右側の小さなバッジで表示（将来は詳細ページへ集約予定）。

フィルタを achieved / unachieved / in_progress に対応しつつ、旧URLの success / failure も互換で受け付け。

Tailwindコンポーネント（.badge, .record-comment）を追加し、コメントは2行で省略。

ランディング等の背景CSSをCSS変数＋フォールバックURLに統一。

変更点

Model: FastingRecord

一覧用メソッド：duration_text, date_for_list, target_hours_label, comment_text, status_key, elapsed_seconds/hm などを追加

スコープ：running / achieved / unachieved

成否自動判定は既存ロジックを維持

Helper: FastingRecordsHelper

list_date, status_badge, comment_snippet, fmt_jp, 内部 to_time_in_zone など

Controller: FastingRecordsController#index

並び順を COALESCE(end_time, start_time) DESC に変更

status パラメータの正規化（success→achieved, failure→unachieved）

ページネーション時にフィルタ保持

View: app/views/fasting_records/index.html.erb

テーブルを廃止し、カード風の行リンクに変更

a11y向け aria-label 付与

CSS: app/assets/stylesheets/landing.css

.badge* と .record-comment を追加

.icon-btn 周りの調整を @layer components へ

image-url(...) を var(--hero-bg, url("/assets/...")) に置換（本番の指紋ファイルに安全）

動作確認

 docker compose exec web bin/rails tailwindcss:build 実行

 /fasting_records で表示確認（進行中・達成・未達成の3パターン）

 フィルタ：すべて / 達成 / 未達成 / 進行中 が切り替わる

 旧URL（?status=success / failure）でも動作

 コメントが2行で省略表示される

 モバイル幅での折返し・タップ領域OK

スクショ

（このPRに貼付）一覧のBefore/After

影響範囲 / リスク

DB変更なし（移行不要）

旧リンク互換あり

app/assets/builds/tailwind.css の取り扱いはリポジトリ方針に依存（含める/除外どちらでも可）
<img width="1308" height="669" alt="スクリーンショット 2025-09-13 19 26 58" src="https://github.com/user-attachments/assets/8ed8befa-02d1-4854-8622-9d018bda0a1d" />
<img width="1305" height="668" alt="スクリーンショット 2025-09-14 13 33 21" src="https://github.com/user-attachments/assets/1456be75-bb1d-4558-b8dc-c1e2ca9eaa39" />

