### PR TITLE
fix(記録): 終了後の開始/終了/目標の編集を禁止し、コメントのみ編集可に。日時表示を秒なしに統一

### DIFF
--- a/app/views/fasting_records/_form.html.erb
+++ b/app/views/fasting_records/_form.html.erb
@@ -1,4 +1,10 @@
-<%= form_with model: @record, local: true, class: "space-y-4", data: { controller: "fasting-form" } do |f| %>
+<%# app/views/fasting_records/_form.html.erb %>
+
+<%= form_with model: @record,
+              local: true,
+              class: "space-y-4",
+              data: (@record.running? ? { controller: "fasting-form" } : {}) do |f| %>
+
   <% if @record.errors.any? %>
     <div class="rounded border border-rose-200 bg-rose-50 p-3 text-rose-700">
       <strong><%= pluralize(@record.errors.count, "error") %> prohibited this record from being saved:</strong>
@@ -8,48 +14,64 @@
     </div>
   <% end %>
 
+  <!-- 開始 -->
   <div>
     <label class="block text-sm text-gray-600">開始</label>
-    <%= f.datetime_local_field :start_time,
-          value:  datetime_local_value(@record.start_time || Time.current),
-          step:   1,
-          data: { "fasting-form-target": "start", action: "input->fasting-form#updateEnd change->fasting-form#updateEnd" } %>
+    <% if @record.running? %>
+      <%= f.datetime_local_field :start_time,
+            value: datetime_local_value(@record.start_time || Time.current),
+            step: 60,
+            data: { "fasting-form-target": "start",
+                    action: "input->fasting-form#updateEnd change->fasting-form#updateEnd" } %>
+    <% else %>
+      <div class="py-2"><%= fmt_jp(@record.start_time) %></div>
+    <% end %>
   </div>
 
+  <!-- 終了 -->
   <div>
-    <label class="block text-sm text-gray-600">終了（自動入力）</label>
-    <%= f.datetime_local_field :end_time,
-          value:  datetime_local_value(@record.end_time || Time.current),
-          min:    datetime_local_value(@record.start_time),
-          step:   1,
-          required: true,
-          data: { "fasting-form-target": "end" } %>
-    <p class="mt-1 text-xs text-gray-500">※ 保存時に「達成/失敗」を自動判定します。</p>
+    <label class="block text-sm text-gray-600">終了</label>
+    <% if @record.running? %>
+      <%= f.datetime_local_field :end_time,
+            value: datetime_local_value(@record.end_time || Time.current),
+            min:   (@record.start_time.present? ? datetime_local_value(@record.start_time) : nil),
+            step:  60,
+            required: true,
+            data: { "fasting-form-target": "end" } %>
+      <p class="mt-1 text-xs text-gray-500">※ 保存時に「達成/未達」を自動判定します。</p>
+    <% else %>
+      <div class="py-2"><%= fmt_jp(@record.end_time) %></div>
+    <% end %>
   </div>
 
+  <!-- 目標 -->
   <div>
     <label class="block text-sm text-gray-600">目標</label>
-    <%= f.select :target_hours,
-      options_for_select(FastingRecord::TARGET_HOURS_CHOICES.map { |h| ["#{h}時間", h] }, @record.target_hours),
-      { include_blank: "選択してください" },
-      class: "border rounded px-2 py-1",
-      data: { "fasting-form-target": "targetHours", action: "change->fasting-form#updateEnd" },
-      required: true %>
+    <% if @record.running? %>
+      <%= f.select :target_hours,
+            options_for_select(FastingRecord::TARGET_HOURS_CHOICES.map { |h| ["#{h}時間", h] }, @record.target_hours),
+            { include_blank: "選択してください" },
+            class: "border rounded px-2 py-1",
+            data: { "fasting-form-target": "targetHours", action: "change->fasting-form#updateEnd" },
+            required: true %>
+    <% else %>
+      <div class="py-2">
+        <%= @record.respond_to?(:target_hours_label) ? @record.target_hours_label : "#{@record.target_hours}h" %>
+      </div>
+    <% end %>
   </div>
 
+  <!-- 結果（表示のみ） -->
   <div>
-    <label class="block text-sm text-gray-600">結果（自動判定）</label>
-    <% if @record.end_time.present? && @record.start_time.present? && @record.target_hours.present? %>
-      <% ok = @record.auto_success? %>
-      <span class="inline-block px-2 py-0.5 rounded text-white <%= ok ? 'bg-emerald-600' : 'bg-rose-600' %>">
-        <%= ok ? '達成' : '失敗' %>
-      </span>
-      <span class="ml-2 text-xs text-gray-500">（保存時に更新）</span>
+    <label class="block text-sm text-gray-600">結果</label>
+    <% if @record.end_time.present? %>
+      <div class="py-2"><%= status_badge(@record) %></div>
     <% else %>
       <span class="text-sm text-gray-500">終了時刻と目標を入力すると自動判定されます</span>
     <% end %>
   </div>
 
+  <!-- コメント -->
   <div>
     <label class="block text-sm text-gray-600">コメント</label>
     <%= f.text_area :comment, rows: 4, class: "w-full border rounded px-2 py-1" %>


### PR DESCRIPTION
概要 / 目的

終了済み記録の信頼性を担保するため、開始/終了/目標の編集をロックし、編集画面はコメントのみにしました。

ついでに 日時表示を統一（秒なし） して、UIのブレと誤操作を減らします。

変更内容
コントローラ

update：終了済み(end_time.present?)のときは以下を受け付けない

start_time / end_time / target_hours をサーバ側で削除

ただし、allow_change_start_time / allow_change_end_time / allow_change_target_hours が明示されている場合のみ例外的に許可

finish：end_time = Time.current 設定後、success を明示再計算して保存

index：COALESCE(end_time, start_time) DESC で新しい順（進行中も含め直近が上に）

ビュー（app/views/fasting_records/_form.html.erb）

終了済み：

「開始」「終了」「目標」は表示のみ（フォーム送信しない＝上書き防止）

「結果」はバッジ表示のみ

編集できるのはコメントだけ

進行中：

datetime_local_field の step: 60 に変更（秒の入力/表示を抑止）

目標変更と終了入力でプレビュー更新（既存の Stimulus 連携を維持）

表示統一

終了済み表示は fmt_jp（曜日＋「時分」）に統一

進行中の入力欄は step:60 で秒を表示しない

なぜこの変更が必要か

「開始→終了の差分＝ファスティング時間」という一貫性を担保するため

終了後に目標時間を下げて「達成」にする等の不正/誤操作の余地を潰すため

秒表示の有無による体裁のブレを解消し、UXをシンプルにするため

影響範囲

FastingRecords の 編集画面と更新処理

一覧の並び順（より直感的に：最新の終了／開始が上位）

DBスキーマ変更なし / 互換性問題なし

動作確認手順

開始→60秒待機→終了→編集

「開始/終了/目標」は入力不可（表示のみ）、コメントのみ編集可

詳細/一覧の時間が約1分で表示されること

進行中の記録を編集

日時入力に秒が表示されない（step: 60）

目標変更や終了入力で（必要なら）プレビューの挙動が崩れていない

finish 実行時、結果(success)が適切に再計算される

一覧が COALESCE(end_time, start_time) DESC で新しい順に並ぶ

例外許可（手動修正が必要な場合のみ）

allow_change_start_time=1 などを付与時に該当値が更新できる

リスクと対応

リスク：過去データの時刻を編集で修正できない
対応：やむを得ない修正は allow_change_* を使った限定的な運用で対応

リスク：フォームのstep指定が一部ブラウザ依存
対応：終了済みは表示のみにしているため、進行中の利便性に限定

スクリーンショット（参考）

終了済み詳細：開始/終了は「YYYY/MM/DD(曜) HH時MM分」表記

終了済み編集：開始/終了/目標＝表示のみ、コメントだけ入力可
（※レビュー環境で実際のUIをご確認ください）
<img width="813" height="503" alt="スクリーンショット 2025-09-14 17 40 55" src="https://github.com/user-attachments/assets/14a6e77a-2f3f-47ee-8f46-c4198ad13c09" />
<img width="271" height="329" alt="スクリーンショット 2025-09-14 17 41 15" src="https://github.com/user-attachments/assets/63fb77d7-71c0-41b7-8d2f-8cdad98eed90" />
