### PR TITLE
記録一覧ページ: タイトルを中央寄せ、サブタイトル/下線を削除

### DIFF
--- a/app/views/fasting_records/index.html.erb
+++ b/app/views/fasting_records/index.html.erb
@@ -1,14 +1,16 @@
 <%# app/views/fasting_records/index.html.erb %>
 
-<div class="sticky top-0 z-50 bg-white/90 backdrop-blur border-b px-4 py-2">
-  <strong>ファスティング記録一覧</strong>
+<!-- 画面上部のスティッキーヘッダー：タイトルは中央、リンクは右上固定 -->
+<div class="sticky top-0 z-50 bg-white/90 backdrop-blur px-4 py-2">
+  <div class="relative max-w-4xl mx-auto">
+    <h1 class="text-lg sm:text-xl font-bold text-center">ファスティング記録一覧</h1>
+    <%= link_to "マイページへ", mypage_path,
+          class: "absolute right-0 top-1/2 -translate-y-1/2 text-blue-600 hover:text-blue-700 underline text-sm" %>
+  </div>
 </div>
 
 <div class="max-w-4xl mx-auto p-4 space-y-6">
-  <div class="flex items-center justify-between">
-    <h1 class="text-xl font-bold">記録一覧</h1>
-    <%= link_to "マイページへ", mypage_path, class: "text-blue-600 hover:text-blue-700 underline" %>
-  </div>
+  <!-- ※ ここでの「記録一覧」見出しは削除済み -->
 
   <!-- フィルタ -->
   <div class="flex gap-2">


### PR DESCRIPTION

## 変更内容
- 画面上部のタイトルを中央寄せに変更
- 旧「記録一覧」見出しを削除
- ヘッダー下のボーダーを削除

## 目的
情報の重複を解消し、視線の移動を最小化して可読性を向上させるため。

## スクリーンショット
（Before / After を貼付）

## 影響範囲
- /fasting_records#index のみ
- a11y: h1 はヘッダー内で維持。フィルタの現在状態は aria-current で表現済み

## 確認項目
- [ ] PC/モバイルでタイトルが中央に表示される
- [ ] スクロール時もヘッダーが重ならない（sticky）
<img width="1306" height="704" alt="スクリーンショット 2025-09-15 14 47 37" src="https://github.com/user-attachments/assets/7b0a84f1-e53a-4834-bfe7-fff9524f7749" />

<img width="1296" height="712" alt="スクリーンショット 2025-09-15 15 00 39" src="https://github.com/user-attachments/assets/4816c803-e28a-49e8-a71e-3d68a29ec13a" />
