### PR TITLE
UI調整(index): 一覧から「目標○○時間」「達成/未達成」を削除し、レイアウトをモバイル中央／PC左寄せで最適化

### DIFF
--- a/app/views/fasting_records/index.html.erb
+++ b/app/views/fasting_records/index.html.erb
@@ -1,6 +1,6 @@
 <%# app/views/fasting_records/index.html.erb %>
 
-<!-- 画面上部のスティッキーヘッダー：タイトルは中央、リンクは右上固定 -->
+<!-- スティッキーヘッダー：タイトル中央、リンク右上固定（下線なし） -->
 <div class="sticky top-0 z-50 bg-white/90 backdrop-blur px-4 py-2">
   <div class="relative max-w-4xl mx-auto">
     <h1 class="text-lg sm:text-xl font-bold text-center">ファスティング記録一覧</h1>
@@ -10,10 +10,8 @@
 </div>
 
 <div class="max-w-4xl mx-auto p-4 space-y-6">
-  <!-- ※ ここでの「記録一覧」見出しは削除済み -->
-
-  <!-- フィルタ -->
-  <div class="flex gap-2">
+  <!-- フィルタ：モバイル=中央 / PC=左 -->
+  <div class="flex flex-wrap gap-2 justify-center sm:justify-start">
     <% raw_cur = params[:status].presence %>
     <%# 旧URLの "success"/"failure" を新語に正規化して扱う %>
     <% cur = case raw_cur when "success" then "achieved" when "failure" then "unachieved" else raw_cur end %>
@@ -45,25 +43,24 @@
       <%= link_to "マイページからファスティングを開始", mypage_path, class: "text-blue-600 hover:text-blue-700 underline font-medium" %>
     </div>
   <% else %>
-    <!-- ▼ 1行=1記録 のサマリー表示 -->
+    <!-- ▼ 1行=1記録：モバイル=中央 / PC=左。目標・達成表示は一覧から削除 -->
     <div class="record-list divide-y divide-gray-100 rounded-lg ring-1 ring-gray-200 overflow-hidden bg-white/80">
       <% @records.each do |r| %>
         <%= link_to fasting_record_path(r),
-                    class: "record-row flex justify-between items-center px-4 py-3 hover:bg-gray-50 transition-colors",
-                    "aria-label": "#{list_date(r.date_for_list)} / ファスティング#{r.duration_text} / 目標 #{r.target_hours_label}" do %>
-          <div class="row-left flex flex-col gap-0.5">
+                    class: "record-row flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 sm:gap-0 px-4 py-3 hover:bg-gray-50 transition-colors text-center sm:text-left",
+                    "aria-label": "#{list_date(r.date_for_list)} / ⌛️#{r.duration_text}" do %>
+
+          <div class="row-left flex flex-col gap-0.5 items-center sm:items-start">
             <div class="record-date text-sm text-gray-600"><%= list_date(r.date_for_list) %></div>
             <div class="record-title font-semibold">
-              ファスティング⌛️<%= r.duration_text %>
+              ⌛️<%= r.duration_text %>
               <% if r.running? %><span class="progress-note text-xs text-gray-500 ml-1">（計測中）</span><% end %>
             </div>
             <%= comment_snippet(r) %>
           </div>
 
-          <div class="row-right flex items-center gap-3">
-            <div class="record-goal text-sm text-gray-700">目標 <%= r.target_hours_label %></div>
-            <div class="record-status whitespace-nowrap"><%= status_badge(r) %></div>
-            <!-- 右端のナビアイコン -->
+          <!-- 右側は矢印のみ -->
+          <div class="row-right flex items-center justify-center sm:justify-end">
             <svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 111.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
             </svg>
@@ -73,7 +70,7 @@
     </div>
 
     <% if defined?(Kaminari) && @records.respond_to?(:current_page) %>
-      <div class="mt-6">
+      <div class="mt-6 flex justify-center sm:justify-start">
         <%= paginate @records, params: { status: params[:status] } %>
       </div>
     <% end %>


### PR DESCRIPTION
目的

一覧ページの情報を「開始/終了からの所要時間＋コメント」の最小限に絞り、詳細は詳細ページへ集約して可読性と操作性を上げるため。

端末に応じて読みやすい整列を行い、モバイルは中央寄せ／PCは左寄せに最適化するため。

変更内容

一覧ページから 「目標○○時間」 と 「達成／未達成」 の表示を削除
→ 詳細ページで表示・判断する前提に統一

各行の右カラムは ナビゲーション矢印のみ を表示

レイアウト

レコード行：モバイルは中央寄せ、PCは左寄せ

フィルタボタン群：モバイル中央／PC左寄せ

ページネーション：モバイル中央／PC左寄せ

アクセシビリティ

行リンクの aria-label を 「日付 / ⌛️所要時間」 のみに更新

旧URLの status=success/failure を achieved/unachieved に正規化して互換維持

スクリーンショット

Before
<img width="1314" height="699" alt="スクリーンショット 2025-09-15 15 16 22" src="https://github.com/user-attachments/assets/b1f9fc43-8a7c-4c9c-af91-9344f96289ae" />


After
<img width="1294" height="691" alt="スクリーンショット 2025-09-15 15 27 23" src="https://github.com/user-attachments/assets/c5872a4a-f26d-4635-8533-792d7c455c8c" />


動作確認

 一覧に「目標○○時間」「達成／未達成」が表示されない

 行全体がリンクで、クリックで詳細ページへ遷移する

 フィルタ選択状態のスタイルが切り替わる（aria-current 付与）

 ページネーションが動作する（フィルタ条件維持）

 モバイルは中央寄せ／PCは左寄せで崩れがない

 旧URL（status=success / status=failure）からの遷移でも期待通り絞り込まれる

影響範囲

fasting_records#index（一覧ページ）の表示のみ

バックエンド処理やAPI、DBスキーマに変更なし（マイグレーションなし）

移行・互換

既存ブックマーク等の status=success/failure は内部で achieved/unachieved に変換して継続利用可能