### PR TITLE
一覧UI: 日付/時間/コメントをSVGアイコン化（カレンダー・時計・吹き出し）

### DIFF
--- a/app/views/fasting_records/index.html.erb
+++ b/app/views/fasting_records/index.html.erb
@@ -48,21 +48,52 @@
       <% @records.each do |r| %>
         <%= link_to fasting_record_path(r),
                     class: "record-row flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 sm:gap-0 px-4 py-3 hover:bg-gray-50 transition-colors text-center sm:text-left",
-                    "aria-label": "#{list_date(r.date_for_list)} / ⌛️#{r.duration_text}" do %>
+                    "aria-label": "#{list_date(r.date_for_list)} / 所要時間 #{r.duration_text}" do %>
 
-          <div class="row-left flex flex-col gap-0.5 items-center sm:items-start">
-            <div class="record-date text-sm text-gray-600"><%= list_date(r.date_for_list) %></div>
-            <div class="record-title font-semibold">
-              ⌛️<%= r.duration_text %>
+          <div class="row-left flex flex-col gap-1 items-center sm:items-start">
+            <!-- 日付：太字＋カレンダーアイコン（SVG） -->
+            <div class="record-date text-sm text-gray-800 font-bold flex items-center gap-1.5">
+              <svg xmlns="http://www.w3.org/2000/svg"
+                   viewBox="0 0 20 20" aria-hidden="true" focusable="false"
+                   style="width:20px;height:20px;display:inline-block;vertical-align:middle;color:#111827;flex:0 0 auto;">
+                <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd"
+                      d="M6 2a1 1 0 0 0-1 1v1H4a2 2 0 0 0-2 2v2h16V6a2 2 0 0 0-2-2h-1V3a1 1 0 1 0-2 0v1H7V3a1 1 0 0 0-1-1zM2 9h16v6a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9z"/>
+              </svg>
+              <time datetime="<%= r.date_for_list.to_date.iso8601 %>"><%= list_date(r.date_for_list) %></time>
+            </div>
+
+            <!-- 所要時間：時計アイコン（SVG）＋テキスト -->
+            <div class="record-title font-semibold flex items-center gap-1.5">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"
+                   style="width:18px;height:18px;display:inline-block;vertical-align:middle;color:#111827;flex:0 0 auto;"
+                   fill="currentColor" aria-hidden="true" focusable="false">
+                <!-- Heroicons 20/solid 風の時計：外円＋短針長針 -->
+                <path fill-rule="evenodd" clip-rule="evenodd"
+                      d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm.75-12a.75.75 0 0 0-1.5 0v3.69l-2.03 2.03a.75.75 0 1 0 1.06 1.06l2.31-2.31a.75.75 0 0 0 .16-.47V6z"/>
+              </svg>
+              <span><%= r.duration_text %></span>
               <% if r.running? %><span class="progress-note text-xs text-gray-500 ml-1">（計測中）</span><% end %>
             </div>
-            <%= comment_snippet(r) %>
+
+            <!-- コメント：吹き出しアイコン（SVG）＋テキスト -->
+            <% snippet_text = strip_tags(comment_snippet(r).to_s).sub(/\A\s*💬\s*/, '') %>
+            <% if snippet_text.present? %>
+              <div class="flex items-center gap-1.5 text-sm text-gray-600">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"
+                     style="width:16px;height:16px;display:inline-block;vertical-align:middle;color:#6B7280;flex:0 0 auto;"
+                     fill="currentColor" aria-hidden="true" focusable="false">
+                  <path fill-rule="evenodd" clip-rule="evenodd"
+                        d="M18 10c0 4-3.582 7-8 7a8.96 8.96 0 0 1-3.5-.7L2 17l1.7-3.4A7.964 7.964 0 0 1 2 10c0-4 3.582-7 8-7s8 3 8 7z"/>
+                </svg>
+                <span><%= snippet_text %></span>
+              </div>
+            <% end %>
           </div>
 
           <!-- 右側は矢印のみ -->
           <div class="row-right flex items-center justify-center sm:justify-end">
             <svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-              <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 111.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z" clip-rule="evenodd"/>
+              <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 0 1 0-1.414L10.586 10 7.293 6.707a1 1 0 1 1 1.414-1.414l4 4a1 1 0 0 1 0 1.414l-4 4a1 1 0 0 1-1.414 0z" clip-rule="evenodd"/>
             </svg>
           </div>
         <% end %>


### PR DESCRIPTION
絵文字（📅⌛️💬）をSVGアイコンに置換して視認性・統一感を改善

所要時間は砂時計→時計アイコンへ変更

aria-label から絵文字を除去し、支援技術で読み上げやすく調整

画面構成や機能への影響なし（見た目のみ）
<img width="1295" height="634" alt="スクリーンショット 2025-09-15 15 48 41" src="https://github.com/user-attachments/assets/ea000617-6b0d-4bd6-9732-504697f7bd28" />
<img width="1324" height="664" alt="スクリーンショット 2025-09-15 16 19 17" src="https://github.com/user-attachments/assets/af21769e-ac88-4418-b856-a6b5c39a4c16" />

