### PR TITLE
一覧をカードUIにパーシャル化／コメントアイコン復活／SVG巨大化を固定サイズで回避

### DIFF
--- a/app/views/fasting_records/_record.html.erb
+++ b/app/views/fasting_records/_record.html.erb
@@ -1,0 +1,44 @@
+<%# ローカル変数: record %>
+<%= link_to fasting_record_path(record),
+            class: "block rounded-xl ring-1 ring-gray-200 bg-white/95 p-4 shadow-sm hover:shadow-md transition focus:outline-none focus:ring-2 focus:ring-emerald-400",
+            "aria-label": "#{list_date(record.date_for_list)} / 所要時間 #{record.duration_text}" do %>
+  <div class="space-y-2">
+    <!-- 日付 -->
+    <div class="flex items-center gap-2 text-sm text-gray-800 font-semibold">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true" focusable="false"
+           style="width:20px;height:20px;display:inline-block;vertical-align:middle;color:#111827;flex:0 0 auto;">
+        <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd"
+              d="M6 2a1 1 0 0 0-1 1v1H4a2 2 0 0 0-2 2v2h16V6a2 2 0 0 0-2-2h-1V3a1 1 0 1 0-2 0v1H7V3a1 1 0 0 0-1-1zM2 9h16v6a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9z"/>
+      </svg>
+      <time datetime="<%= record.date_for_list.to_date.iso8601 %>">
+        <%= list_date(record.date_for_list) %>
+      </time>
+    </div>
+
+    <!-- 所要時間 -->
+    <div class="flex items-center gap-2">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true" focusable="false"
+           style="width:18px;height:18px;display:inline-block;vertical-align:middle;color:#111827;flex:0 0 auto;" fill="currentColor">
+        <path fill-rule="evenodd" clip-rule="evenodd"
+              d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm.75-12a.75.75 0 0 0-1.5 0v3.69l-2.03 2.03a.75.75 0 1 0 1.06 1.06l2.31-2.31a.75.75 0 0 0 .16-.47V6z"/>
+      </svg>
+      <span class="font-bold text-gray-900 whitespace-nowrap"><%= record.duration_text %></span>
+      <% if record.running? %>
+        <span class="ml-1 text-xs text-gray-500 whitespace-nowrap">（計測中）</span>
+      <% end %>
+    </div>
+
+    <!-- コメント（吹き出し + 2行省略） -->
+    <% snippet_text = strip_tags(comment_snippet(record).to_s).sub(/\A\s*💬\s*/, '') %>
+    <% if snippet_text.present? %>
+      <div class="flex items-start gap-2 text-sm text-gray-600">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true" focusable="false"
+             style="width:16px;height:16px;display:inline-block;vertical-align:middle;color:#6B7280;flex:0 0 auto;margin-top:2px;">
+          <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd"
+                d="M18 10c0 4-3.582 7-8 7a8.96 8.96 0 0 1-3.5-.7L2 17l1.7-3.4A7.964 7.964 0 0 1 2 10c0-4 3.582-7 8-7s8 3 8 7z"/>
+        </svg>
+        <p class="record-comment"><%= snippet_text %></p>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/fasting_records/index.html.erb
+++ b/app/views/fasting_records/index.html.erb
@@ -6,21 +6,25 @@
          when "failure"   then "unachieved"
          else raw_cur
          end %>
+
 <!-- スティッキーヘッダー -->
 <div class="sticky top-0 z-50 bg-white/90 backdrop-blur">
-  <!-- ★ relative を必ず付ける（absolute の基準） -->
+  <!-- 絶対配置の基準にするため relative を付与 -->
   <div class="max-w-4xl mx-auto px-4 py-2 relative">
-    <!-- 中央タイトル（このまま text-center でOK） -->
+    <!-- タイトルは中央寄せ -->
     <h1 class="text-center text-lg sm:text-xl font-bold">
       ファスティング記録一覧
     </h1>
 
-    <!-- 右上：絞り込み（絶対配置で右端＆縦中央 / 右余白も調整） -->
+    <!-- 右上：絞り込み（右端 & 縦中央） -->
     <%= form_with url: fasting_records_path, method: :get, local: true,
                   html: { class: "absolute right-2 sm:right-4 top-1/2 -translate-y-1/2 inline-flex items-center gap-2" } do %>
       <label for="status" class="text-sm text-gray-700">絞り込み</label>
       <%= select_tag :status,
-            options_for_select([["すべて",""],["目標達成","achieved"],["未達成","unachieved"],["進行中","in_progress"]], (cur || "").to_s),
+            options_for_select(
+              [["すべて",""], ["目標達成","achieved"], ["未達成","unachieved"], ["進行中","in_progress"]],
+              (cur || "").to_s
+            ),
             include_blank: false,
             onchange: "this.form.requestSubmit ? this.form.requestSubmit() : this.form.submit()",
             class: "pl-3 pr-3 py-1.5 rounded-md ring-1 ring-gray-300 bg-white text-gray-800 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900 text-sm" %>
@@ -38,58 +42,13 @@
       <%= link_to "マイページからファスティングを開始", mypage_path, class: "text-blue-600 hover:text-blue-700 underline font-medium" %>
     </div>
   <% else %>
-    <div class="record-list divide-y divide-gray-100 rounded-lg ring-1 ring-gray-200 overflow-hidden bg-white/80">
-      <% @records.each do |r| %>
-        <%= link_to fasting_record_path(r),
-            class: "record-row flex flex-col sm:flex-row sm:justify-between sm:items-center gap-2 sm:gap-0 px-4 py-3 hover:bg-gray-50 transition-colors text-center sm:text-left",
-            "aria-label": "#{list_date(r.date_for_list)} / 所要時間 #{r.duration_text}" do %>
-
-          <div class="row-left flex flex-col gap-1 items-center sm:items-start">
-            <div class="record-date text-sm text-gray-800 font-bold flex items-center gap-1.5">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" aria-hidden="true" focusable="false"
-                   style="width:20px;height:20px;display:inline-block;vertical-align:middle;color:#111827;flex:0 0 auto;">
-                <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd"
-                      d="M6 2a1 1 0 0 0-1 1v1H4a2 2 0 0 0-2 2v2h16V6a2 2 0 0 0-2-2h-1V3a1 1 0 1 0-2 0v1H7V3a1 1 0 0 0-1-1zM2 9h16v6a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9z"/>
-              </svg>
-              <time datetime="<%= r.date_for_list.to_date.iso8601 %>"><%= list_date(r.date_for_list) %></time>
-            </div>
-
-            <div class="record-title font-semibold flex items-center gap-1.5">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"
-                   style="width:18px;height:18px;display:inline-block;vertical-align:middle;color:#111827;flex:0 0 auto;"
-                   fill="currentColor" aria-hidden="true" focusable="false">
-                <path fill-rule="evenodd" clip-rule="evenodd"
-                      d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm.75-12a.75.75 0 0 0-1.5 0v3.69l-2.03 2.03a.75.75 0 1 0 1.06 1.06l2.31-2.31a.75.75 0 0 0 .16-.47V6z"/>
-              </svg>
-              <span><%= r.duration_text %></span>
-              <% if r.running? %><span class="progress-note text-xs text-gray-500 ml-1">（計測中）</span><% end %>
-            </div>
-
-            <% snippet_text = strip_tags(comment_snippet(r).to_s).sub(/\A\s*💬\s*/, '') %>
-            <% if snippet_text.present? %>
-              <div class="flex items-center gap-1.5 text-sm text-gray-600">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"
-                     style="width:16px;height:16px;display:inline-block;vertical-align:middle;color:#6B7280;flex:0 0 auto;"
-                     fill="currentColor" aria-hidden="true" focusable="false">
-                  <path fill-rule="evenodd" clip-rule="evenodd"
-                        d="M18 10c0 4-3.582 7-8 7a8.96 8.96 0 0 1-3.5-.7L2 17l1.7-3.4A7.964 7.964 0 0 1 2 10c0-4 3.582-7 8-7s8 3 8 7z"/>
-                </svg>
-                <span><%= snippet_text %></span>
-              </div>
-            <% end %>
-          </div>
-
-          <div class="row-right flex items-center justify-center sm:justify-end">
-            <svg class="w-5 h-5 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-              <path fill-rule="evenodd" d="M7.293 14.707a1 1 0 0 1 0-1.414L10.586 10 7.293 6.707a1 1 0 1 1 1.414-1.414l4 4a1 1 0 0 1 0 1.414l-4 4a1 1 0 0 1-1.414 0z" clip-rule="evenodd"/>
-            </svg>
-          </div>
-        <% end %>
-      <% end %>
+    <!-- カードのグリッド（1列 → md以上で2列） -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <%= render partial: "record", collection: @records, as: :record %>
     </div>
 
     <% if defined?(Kaminari) && @records.respond_to?(:current_page) %>
-      <div class="mt-6 flex justify-center sm:justify-start">
+      <div class="mt-6 flex justify-center md:justify-start">
         <%= paginate @records, params: { status: params[:status] } %>
       </div>
     <% end %>


### PR DESCRIPTION
### 目的
- 記録一覧の見通しを良くし、アプリらしい見た目に改善するため
- ビューの保守性向上（パーシャル化）

### 変更点
- `app/views/fasting_records/_record.html.erb` を新規作成し、1レコードの表示をパーシャル化
- 一覧をグリッドレイアウト（1列→md以上で2列）に変更
- コメントアイコン（吹き出し）を復活
- SVGが巨大化する問題に対し、アイコンはインラインstyleでサイズを固定

### 動作確認
- 一覧表示：OK
- コメントスニペット表示：OK（2行省略）
- 進行中バッジ表示：OK
- リンク遷移：OK
- スマホ／PCでの崩れなし

### スクショ
Before
<img width="1296" height="597" alt="スクリーンショット 2025-09-15 23 07 57" src="https://github.com/user-attachments/assets/7b5145e3-5481-4f98-9d8f-eee7a5bc787e" />

After
<img width="1305" height="603" alt="スクリーンショット 2025-09-15 23 08 27" src="https://github.com/user-attachments/assets/cb0ba864-27e8-4438-9203-a38a1357a0d0" />

### 補足
- さらなる微調整や装飾は次PRで対応予定
