### PR TITLE
目標18h 以上の開始時に「長時間の注意」画面を追加／24h 以上は強調表示

### DIFF
--- a/app/views/health_notice/long.html.erb
+++ b/app/views/health_notice/long.html.erb
@@ -5,34 +5,43 @@
   <div class="w-full max-w-xl rounded-2xl bg-white/90 backdrop-blur shadow-2xl ring-1 ring-gray-200 p-6 sm:p-8">
 
     <!-- 見出し + サブ見出し -->
-    <h1 class="text-xl sm:text-2xl font-bold text-center tracking-tight">健康と安全について</h1>
+    <h1 class="text-lg sm:text-xl font-bold text-center tracking-tight">長時間のファスティングについて</h1>
     <p class="mt-1 text-center text-xs sm:text-sm text-gray-500">
-      バージョン <%= Rails.configuration.x.health_notice.version %>
+      目標時間：<strong><%= @hours %>時間</strong>
     </p>
 
     <!-- 本文（中央寄せ、箇条書きは inline-block で自然な左右幅） -->
     <div class="mt-5 sm:mt-6 text-sm sm:text-base text-gray-700 text-center">
+      <p class="mb-2">以下の注意事項を必ず確認してください。</p>
       <ul class="inline-block text-left list-disc pl-5 space-y-1">
-        <li>本アプリは医療行為ではありません。体調や持病・服薬によってはリスクが生じます。</li>
-        <li>該当する方（妊娠/授乳、小児/思春期、摂食障害の既往/症状、糖尿病など慢性疾患、低栄養）は必ず医療専門職に相談してください。</li>
-        <li>体調不良時は直ちに中止し、水分・電解質を補給のうえ医療機関に相談してください。</li>
+        <li>水分・電解質の補給を忘れないでください。</li>
+        <li>体調不良時は直ちに中止してください。</li>
       </ul>
+
+      <% if @very_long %>
+        <div class="mt-4 sm:mt-5 rounded-md border border-rose-300 bg-rose-50 text-rose-800 p-3 text-left inline-block">
+          <p class="font-semibold">24時間以上のファスティングは特に注意が必要です。</p>
+          <p class="text-sm mt-1">無理をせず、体調に異変があればすぐに中止してください。</p>
+        </div>
+      <% end %>
     </div>
 
-    <%= form_with url: health_notice_path, method: :post, local: true,
-          html: { id: "health-notice-form", class: "mt-6 sm:mt-7 space-y-4" } do %>
+    <%= form_with url: start_fasting_records_path, method: :post, local: true,
+          html: { id: "long-notice-form", class: "mt-6 sm:mt-7 space-y-4" } do %>
+      <%= hidden_field_tag :target_hours, @hours %>
+      <%= hidden_field_tag :confirmed_long_notice, "1" %>
 
       <!-- 同意チェック（中央寄せ） -->
       <div class="flex items-center justify-center gap-2">
-        <%= check_box_tag :agree, "1", false, id: "agree", class: "mt-0.5" %>
-        <label for="agree" class="text-sm text-gray-800">以上を読み理解しました（同意する）</label>
+        <%= check_box_tag :agree_long, "1", false, id: "agree_long", class: "mt-0.5" %>
+        <label for="agree_long" class="text-sm text-gray-800">上記の注意点を理解しました（同意する）</label>
       </div>
 
       <!-- ボタン（中央寄せ） -->
       <div class="mt-5 text-center">
-        <%= button_tag "同意して続ける",
+        <%= button_tag "同意して開始する",
               type: :submit,
-              id: "agree-submit",
+              id: "agree-long-submit",
               class: "btn btn-primary px-6 py-2 text-sm",
               disabled: true,
               aria: { disabled: true } %>
@@ -44,8 +53,8 @@
 <%= javascript_tag nonce: true do %>
   (function () {
     function init() {
-      var cb  = document.getElementById('agree');
-      var btn = document.getElementById('agree-submit');
+      var cb  = document.getElementById('agree_long');
+      var btn = document.getElementById('agree-long-submit');
       if (!cb || !btn) return;
       function sync() {
         var on = cb.checked;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,12 +3,15 @@ Rails.application.routes.draw do
   devise_for :users
 
   # --- 健康と安全（同意フロー / 単数リソース） ---
-  # 画面: GET  /health-notice  -> HealthNoticeController#show
-  # 同意: POST /health-notice  -> HealthNoticeController#create
+  # 画面:  GET  /health-notice        -> HealthNoticeController#show
+  # 同意:  POST /health-notice        -> HealthNoticeController#create
+  # 長時間: GET  /health-notice/long  -> HealthNoticeController#long
   resource :health_notice,
            only: [ :show, :create ],
            controller: "health_notice",
-           path: "health-notice"
+           path: "health-notice" do
+    get :long
+  end
 
   # --- マイページ（ログイン後の着地点） ---
   resource :mypage, only: :show  # /mypage -> MypagesController#show


### PR DESCRIPTION
- ## 概要
README の仕様に沿って、18h 以上で追加の注意確認、24h 以上は強調表示を実装しました。
注意画面（通常/長時間）ともに中央寄せ・余白を調整し、同意チェック未済はボタン無効化にしています。

## 変更点
- ルーティング: `GET /health-notice/long` を追加
- `FastingRecordsController#start` に 18h+ の分岐を追加（`confirmed_long_notice=1` で復帰）
- `health_notice/long.html.erb` 新規作成
- `health_notice/show.html.erb` のレイアウト微調整（中央寄せ/余白統一）

## 動作確認
- 目標時間 17h → そのまま開始
- 目標時間 18h〜23h → 長時間注意を表示し、同意で開始
- 目標時間 24h 以上 → 長時間注意に強調ブロックが表示される
- 同意チェック未済はボタン無効
<img width="1309" height="343" alt="スクリーンショット 2025-09-18 19 09 19" src="https://github.com/user-attachments/assets/017e49bc-d980-4cbb-b23f-c5509b158bbb" />
<img width="1313" height="336" alt="スクリーンショット 2025-09-18 19 09 35" src="https://github.com/user-attachments/assets/e251e482-611f-4a55-84aa-5541cab2b33e" />
<img width="1305" height="296" alt="スクリーンショット 2025-09-18 19 10 09" src="https://github.com/user-attachments/assets/fcc97df9-1834-4140-9767-4699e13a8489" />

## 備考
- 関連: #59
- Closes #62 
