### PR TITLE
早期デプロイ（Render）: Blueprint追加・本番PostgreSQL化（#69）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,56 +1,47 @@
+# Gemfile
 source "https://rubygems.org"
 ruby "3.2.2"
-gem "tailwindcss-rails"
-gem "kaminari"
 
-# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
+# --- Core ---
 gem "rails", "~> 8.0.2"
-# The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
-gem "sprockets-rails"
-# Use mysql as the database for Active Record
-gem "mysql2", "~> 0.5"
-# Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
-# Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
-gem "importmap-rails"
-# Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-gem "turbo-rails"
-# Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
-gem "stimulus-rails"
-# Use Dart SASS [https://github.com/rails/dartsass-rails]
-gem "dartsass-rails"
-# Use Redis adapter to run Action Cable in production
-# gem "redis", ">= 4.0.1"
-
-# Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
-# gem "kredis"
-
-# Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[ windows jruby ]
-
-# Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
-# Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+# --- Frontend / Assets ---
+gem "importmap-rails"
+gem "turbo-rails"
+gem "stimulus-rails"
+gem "sprockets-rails"      # 必要なら残す（Rails 8 でも使用可）
+gem "tailwindcss-rails"    # Node不要
+gem "dartsass-rails"       # Node不要（Sassビルド）
 
+# --- App libs ---
+gem "kaminari"
+gem "devise", "~> 4.9"
+
+# Windows/JRuby向けタイムゾーンデータ
+gem "tzinfo-data", platforms: %i[windows jruby]
+
+# --- Production（Heroku）---
+# HerokuではPostgresを使う
+group :production do
+  gem "pg", "~> 1.5"
+end
+
+# --- Development / Test ---
 group :development, :test do
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
+  # ローカル/テストはMySQLを利用（Herokuでは使わない）
+  gem "mysql2", "~> 0.5"
 
-  # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
+  # デバッグ & 静的解析
+  gem "debug", platforms: %i[mri windows], require: "debug/prelude"
   gem "brakeman", require: false
-
-  # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
 end
 
 group :development do
-  # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
 end
 
-gem "devise", "~> 4.9"
+# ActiveStorage の画像変換を使う場合は有効化
+# gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,6 +174,9 @@ GEM
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
+    pg (1.6.2-aarch64-linux)
+    pg (1.6.2-arm64-darwin)
+    pg (1.6.2-x86_64-linux)
     pp (0.6.2)
       prettyprint
     prettyprint (0.2.0)
@@ -324,6 +327,7 @@ DEPENDENCIES
   importmap-rails
   kaminari
   mysql2 (~> 0.5)
+  pg (~> 1.5)
   puma (>= 5.0)
   rails (~> 8.0.2)
   rubocop-rails-omakase

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec puma -C config/puma.rb
+release: bundle exec rails db:migrate

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,14 +1,6 @@
-# MySQL. Versions 5.5.8 and up are supported.
-#
-# Install the MySQL driver
-#   gem install mysql2
-#
-# Ensure the MySQL gem is defined in your Gemfile
-#   gem "mysql2"
-#
-# And be sure to use new-style password hashing:
-#   https://dev.mysql.com/doc/refman/5.7/en/password-hashing.html
-#
+# config/database.yml
+
+# Docker（dev/test）は MySQL を使用
 default: &default
   adapter: mysql2
   encoding: utf8mb4
@@ -22,35 +14,12 @@ development:
   <<: *default
   database: <%= ENV.fetch("MYSQL_DATABASE", "fasty_app_development") %>
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: fasty_app_test
+  database: <%= ENV.fetch("MYSQL_TEST_DATABASE", "fasty_app_test") %>
 
-# As with config/credentials.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password or a full connection URL as an environment
-# variable when you boot the app. For example:
-#
-#   DATABASE_URL="mysql2://myuser:mypass@localhost/somedatabase"
-#
-# If the connection URL is provided in the special DATABASE_URL environment
-# variable, Rails will automatically merge its configuration values on top of
-# the values provided in this file. Alternatively, you can specify a connection
-# URL environment variable explicitly:
-#
-#   production:
-#     url: <%= ENV["MY_APP_DATABASE_URL"] %>
-#
-# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full overview on how database connection configuration can be specified.
-#
+# Heroku（production）は Postgres を使用（DATABASE_URL をそのまま参照）
+# ※ default を継承しない（adapter が mysql2 になってしまうため）
 production:
-  <<: *default
-  database: fasty_app_production
-  username: fasty_app
-  password: <%= ENV["FASTY_APP_DATABASE_PASSWORD"] %>
+  url: <%= ENV.fetch("DATABASE_URL") %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,34 +1,23 @@
-# This configuration file will be evaluated by Puma. The top-level methods that
-# are invoked here are part of Puma's configuration DSL. For more information
-# about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.
+# config/puma.rb
 
-# Puma starts a configurable number of processes (workers) and each process
-# serves each request in a thread from an internal thread pool.
-#
-# The ideal number of threads per worker depends both on how much time the
-# application spends waiting for IO operations and on how much you wish to
-# to prioritize throughput over latency.
-#
-# As a rule of thumb, increasing the number of threads will increase how much
-# traffic a given process can handle (throughput), but due to CRuby's
-# Global VM Lock (GVL) it has diminishing returns and will degrade the
-# response time (latency) of the application.
-#
-# The default is set to 3 threads as it's deemed a decent compromise between
-# throughput and latency for the average Rails application.
-#
-# Any libraries that use a connection pool or another resource pool should
-# be configured to provide at least as many connections as the number of
-# threads. This includes Active Record's `pool` parameter in `database.yml`.
-threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
-threads threads_count, threads_count
+# スレッド数（最小/最大）
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5).to_i
+min_threads_count = ENV.fetch("RAILS_MIN_THREADS", max_threads_count).to_i
+threads min_threads_count, max_threads_count
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT", 3000)
+# ポート・環境
+port        ENV.fetch("PORT", 3000)
+environment ENV.fetch("RAILS_ENV", "development")
 
-# Allow puma to be restarted by `bin/rails restart` command.
+# PIDファイル（Herokuでは未使用だが他環境向けに用意）
+pidfile     ENV.fetch("PIDFILE", "tmp/pids/server.pid")
+
+# Herokuの並列ワーカー数（環境変数がある場合のみ設定）
+# 例: heroku config:set WEB_CONCURRENCY=2
+if ENV["WEB_CONCURRENCY"]
+  workers Integer(ENV.fetch("WEB_CONCURRENCY"))
+  preload_app!
+end
+
+# bin/rails restart で再起動できるように
 plugin :tmp_restart
-
-# Specify the PID file. Defaults to tmp/pids/server.pid in development.
-# In other environments, only set the PID file if requested.
-pidfile ENV["PIDFILE"] if ENV["PIDFILE"]

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,27 @@
+databases:
+  - name: fasty-db
+    databaseName: fasty_prod
+    user: fasty
+
+services:
+  - type: web
+    name: fasty-web
+    env: ruby
+    plan: starter          # UIで後から変更可
+    autoDeploy: true
+    buildCommand: |
+      bundle install
+      bundle exec rails assets:precompile
+    startCommand: bundle exec puma -C config/puma.rb
+    healthCheckPath: /
+    envVars:
+      - key: RAILS_ENV
+        value: production
+      - key: RAILS_MASTER_KEY
+        sync: false        # デプロイ後、Renderのダッシュボードで入力
+      - key: RAILS_SERVE_STATIC_FILES
+        value: "1"
+      - key: DATABASE_URL
+        fromDatabase:
+          name: fasty-db
+          property: connectionString


### PR DESCRIPTION
### 目的
- デプロイ先を **Heroku → Render** に変更し、MVPの「早期デプロイ」を達成する（課題要件）。
- Issue: Closes #69

### 変更点
- add: `render.yaml`（Blueprintで Web + Managed PostgreSQL を一括作成）
- update: `Gemfile` 本番のみ `pg`、dev/test は `mysql2`
- update: `config/database.yml` 本番は `DATABASE_URL` を参照
- update: `config/puma.rb`（WEB_CONCURRENCY対応・preload_app!）
- keep: `Procfile` はHeroku用（Renderでは未使用／残置）

### デプロイ手順（Render）
1. Render → **New → Blueprint** → このリポジトリを選択
2. 生成された Web Service の **Environment** に `RAILS_MASTER_KEY` を追加
3. 初回デプロイ完了を確認（ログで `db:migrate` 成功を確認）
4. 公開URLを下記に追記

### 動作確認
- ログイン不要ページ（トップ）が Render の公開URLで表示されること
- DB接続OK（マイグレーション成功）

### 影響範囲
- 開発/テストの MySQL 運用は現状維持。本番のみ Postgres。

### TODO（レビュ後/マージ後の運用）
- [ ] Render Blueprint で作成
- [ ] `RAILS_MASTER_KEY` を設定
- [ ] 初回デプロイ成功
- [ ] 公開URLをIssue #69 に記載
