### PR TITLE
ログイン後フッターにアイコン付きボトムナビを実装（記録一覧/瞑想/マイページ）

### DIFF
--- a/app/assets/stylesheets/drawer.css
+++ b/app/assets/stylesheets/drawer.css
@@ -64,3 +64,42 @@ header.bg-brand-header nav,
 header.bg-brand-header a,
 header.bg-brand-header .btn,
 header.bg-brand-header .flex { align-items: center; }
+/* ==== Bottom App Nav（ログイン後） ===================== */
+/* ここを差し替え：中央寄せの“内容幅”グリッドに */
+.footer-app__nav{
+  display: grid;
+  grid-auto-flow: column;              /* 横方向に並べる */
+  grid-auto-columns: max-content;      /* 各リンクは内容幅だけ */
+  justify-content: center;             /* コンテナ中央に寄せる */
+  align-items: center;
+  gap: clamp(1.5rem, 5vw, 3.25rem);    /* 3つの間隔（少し狭め＆可変） */
+  margin-inline: auto;
+  max-width: min(820px, 92vw);         /* 画面が広い時も中央にコンパクト */
+}
+
+/* 各リンクは内容幅だけを占有（横いっぱいに広がらないように） */
+.footer-app__link{
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  inline-size: max-content;
+  gap: .3rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+/* アイコン・ラベル（お好みのサイズのままでOK） */
+.footer-app__link svg{
+  width: 32px; height: 32px; display: block;
+  color:#111;
+  transition: transform .15s ease, color .15s ease, filter .15s ease;
+}
+@media (min-width:640px){
+  .footer-app__link svg{ width:34px; height:34px; }
+}
+.footer-app__link span{
+  font-size:.8rem; line-height:1; color:#fff; letter-spacing:.02em;
+}
+
+/* ホバー/アクティブ */
+.footer-app__link:hover svg{ transform: translateY(-1px); color:#000; }
+.footer-app__link.is-active svg{ color:#fff; filter: drop-shadow(0 2px 8px rgba(0,0,0,.25)); }
+.footer-app__link.is-active span{ color:#fff; font-weight:700; }

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,28 +1,70 @@
 <!-- app/views/shared/_footer.html.erb -->
-<% thick = (defined?(user_signed_in?) && user_signed_in?) ? 'footer-thick' : '' %>
+<% if user_signed_in? %>
+  <!-- ログイン後：ボトムナビ -->
+  <footer class="bg-brand-header text-white">
+    <div class="footer-app footer-thick mx-auto max-w-[1200px] px-4 md:px-6">
+      <nav class="footer-app__nav" aria-label="アプリフッター">
 
-<footer class="bg-brand-header text-white">
-  <div class="<%= [thick, 'mx-auto max-w-[1200px] px-4 md:px-8 py-4 sm:py-5 pb-safe'].join(' ') %>">
-    <div class="flex flex-col sm:flex-row items-center justify-between gap-3 sm:gap-4">
-      <!-- 左：著作権表示 -->
-      <p class="mr-auto sm:mr-0 text-sm sm:text-base opacity-90 select-none">
-        &copy; <%= Time.zone.now.year %> Fasty
-      </p>
+        <!-- 記録一覧 -->
+        <%= link_to (respond_to?(:fasting_records_path) ? fasting_records_path : "#"),
+          class: "footer-app__link #{(respond_to?(:fasting_records_path) && current_page?(fasting_records_path)) ? 'is-active' : ''}",
+          aria: { label: "記録一覧" } do %>
+          <!-- ペン（ソリッド） -->
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M15.232 5.232a2.5 2.5 0 0 1 3.536 3.536l-8.5 8.5-4.268.732.732-4.268 8.5-8.5Z M4 20h16v2H4z" fill="currentColor"/>
+          </svg>
+          <span>記録一覧</span>
+        <% end %>
 
-      <!-- 右：法務系リンク -->
-      <nav class="flex items-center gap-6 sm:gap-8 text-sm whitespace-nowrap" aria-label="フッターナビ">
-        <%= link_to "健康と安全", health_notice_path,
-              class: "opacity-95 hover:opacity-100 hover:underline" %>
-        <%= link_to "利用規約",
-              (defined?(terms_path) ? terms_path : "#"),
-              class: "opacity-95 hover:opacity-100 hover:underline" %>
-        <%= link_to "お問い合わせ",
-              (defined?(contact_path) ? contact_path : "#"),
-              class: "opacity-95 hover:opacity-100 hover:underline" %>
-        <%= link_to "プライバシーポリシー",
-              (defined?(privacy_path) ? privacy_path : "#"),
-              class: "opacity-95 hover:opacity-100 hover:underline" %>
+        <!-- 瞑想（B. ロータス：花びら風） -->
+        <%= link_to (respond_to?(:meditations_path) ? meditations_path : "#"),
+          class: "footer-app__link #{(respond_to?(:meditations_path) && current_page?(meditations_path)) ? 'is-active' : ''}",
+          aria: { label: "瞑想" } do %>
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <!-- 中央の花びら -->
+            <path d="M12 4.8c2.0 2.2 3.0 4.2 3.0 6.0c-1.6.8-3.0.8-3.0.8s-1.4 0-3.0-.8c0-1.8 1.0-3.8 3.0-6.0Z"
+                  fill="none" stroke="currentColor" stroke-width="2.0" stroke-linejoin="round"/>
+            <!-- 左右の花びら -->
+            <path d="M6.5 7.4c.9 2.2 2.4 3.7 4.6 4.7c-2.3.8-4.2.7-6.1-.1c.1-1.7.6-3.2 1.5-4.6Z"
+                  fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
+            <path d="M17.5 7.4c-.9 2.2-2.4 3.7-4.6 4.7c2.3.8 4.2.7 6.1-.1c-.1-1.7-.6-3.2-1.5-4.6Z"
+                  fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
+            <!-- ベースのライン（花台） -->
+            <path d="M4 18c5.3 1.4 10.7 1.4 16 0"
+                  fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/>
+          </svg>
+          <span>瞑想</span>
+        <% end %>
+
+        <!-- マイページ -->
+        <%= link_to (respond_to?(:mypage_path) ? mypage_path : "#"),
+          class: "footer-app__link #{(respond_to?(:mypage_path) && current_page?(mypage_path)) ? 'is-active' : ''}",
+          aria: { label: "マイページ" } do %>
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5Zm-8 8a8 8 0 0 1 16 0v1H4z" fill="currentColor"/>
+          </svg>
+          <span>マイページ</span>
+        <% end %>
+
       </nav>
     </div>
-  </div>
-</footer>
+  </footer>
+
+<% else %>
+  <!-- ログイン前：コピーライト＋法務リンク -->
+  <footer class="bg-brand-header text-white">
+    <div class="mx-auto max-w-[1200px] px-4 md:px-8 py-4 sm:py-5 pb-safe">
+      <div class="flex items-center justify-between gap-4">
+        <p class="text-sm sm:text-base opacity-90 select-none">
+          &copy; <%= Time.zone.now.year %> Fasty
+        </p>
+        <nav class="flex items-center gap-6 sm:gap-8 text-sm whitespace-nowrap" aria-label="フッターナビ">
+          <%= link_to "健康と安全", health_notice_path, class: "opacity-95 hover:opacity-100 hover:underline" %>
+          <%= link_to "利用規約", (respond_to?(:terms_path) ? terms_path : "#"), class: "opacity-95 hover:opacity-100 hover:underline" %>
+          <%= link_to "お問い合わせ", (respond_to?(:contact_path) ? contact_path : "#"), class: "opacity-95 hover:opacity-100 hover:underline" %>
+          <%= link_to "プライバシーポリシー", (respond_to?(:privacy_path) ? privacy_path : "#"), class: "opacity-95 hover:opacity-100 hover:underline" %>
+        </nav>
+      </div>
+    </div>
+  </footer>
+<% end %>


### PR DESCRIPTION
概要

ログイン後画面のフッターを、アイコン付きのボトムナビに刷新しました。

ログイン前は従来どおりコピーライト＋法務リンク（控えめサイズ）を維持します。

ヘッダー/フッターの縦幅は、モバイルでの視認性とタップ性を優先しつつ控えめに調整済み。

Closes #74

変更内容

app/views/shared/_footer.html.erb

user_signed_in? で分岐し、ログイン後のみボトムナビ（3項目）を表示

記録一覧：fasting_records_path

瞑想：meditations_path

マイページ：mypage_path

現在ページは .is-active を付与しアイコン＆ラベルを白で強調

ログイン前のコピーライト＋法務リンクは現状維持

app/assets/stylesheets/drawer.css

フッター用スタイルを追記（アプリ用ナビ）

3分割グリッド配置、中央寄せ

アイコンの塗りは黒（currentColor）、アクティブ時は白＋軽いシャドウ

ラベルの可読性・タップ領域（最小44–48px相当）を確保

pb-safe 対応（iPhoneノッチ等のセーフエリア）

デザイン・サイズ感

モバイル想定で強調しすぎないが明確に押せるサイズ感（xsで約28–32pxアイコン、smで微増）

フッターはログイン後のみ厚みを持たせ、主役UIとして機能

ログイン前フッターは控えめ（コピーライト＋法務リンクのみ）

動作確認（手順）

ログイン前

トップ：コピーライト＋法務リンクのみが表示されること

ログイン後

画面下部に「記録一覧 / 瞑想 / マイページ」の3アイコンが表示

各リンク押下で該当画面へ遷移

現在ページの項目が白で強調されること（.is-active）

レスポンシブ

320px / 375px / 768px 幅で崩れないこと

iPhone ノッチ環境（DevTools の iPhone シミュレータ等）で セーフエリアに干渉しないこと

アクセシビリティ

各リンクに aria-label が付与されていること

タップ領域が十分（おおむね44px以上）であること

影響範囲

ビュー（フッター）とCSSの追加・調整のみ

既存のバックエンド／ルーティングには影響なし（既存パスを利用）

リスク・懸念

想定より小さく表示される環境があれば、footer-app--lg などの拡張クラスで微調整可能

ブラウザキャッシュでCSSが更新されない場合はハードリロードが必要なことあり

フォールバック:
問題があれば is-active 強調やサイズ関連のクラスを一時的に外す／display: none; でボトムナビを隠すことで即時回避可能。最悪はこのPRのリバートで戻せます。

スクリーンショット
ログイン後：ボトムナビ（記録一覧 / 瞑想 / マイページ）
 before
<img width="1231" height="718" alt="スクリーンショット 2025-10-10 14 05 32" src="https://github.com/user-attachments/assets/f06f3baf-720d-4cb3-981d-ab582ef58394" />

after
<img width="1233" height="719" alt="スクリーンショット 2025-10-10 14 05 13" src="https://github.com/user-attachments/assets/ea25b4ab-614b-491b-870b-1835539fa3c0" />

<img width="1229" height="718" alt="スクリーンショット 2025-10-10 14 13 43" src="https://github.com/user-attachments/assets/efd966c3-a733-4b72-bf3b-236d59cfd875" />

<img width="1231" height="720" alt="スクリーンショット 2025-10-10 14 13 52" src="https://github.com/user-attachments/assets/899c9e58-4558-4ef9-9d0f-00dc7e28fd13" />




ログイン前：コピーライト＋法務リンク（控えめ）
<img width="1230" height="719" alt="スクリーンショット 2025-10-10 14 12 17" src="https://github.com/user-attachments/assets/9719eb13-da1b-4d01-b216-b4489a4500c2" />


チェックリスト

 ログイン前後で表示が適切に切り替わる

 3リンクが期待どおりのパスに遷移

 アクティブ表示が正しく切り替わる

 セーフエリア対応（pb-safe）

 タップ領域・アクセシビリティ確認

Closes #74