### PR TITLE
feat(mypage): 挨拶バーを追加（中央・太字）。マイページのみ表示

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,11 @@
+# app/helpers/users_helper.rb
+module UsersHelper
+  def display_name(user)
+    return "ゲスト" unless user
+    if user.respond_to?(:name) && user.name.present?
+      user.name
+    else
+      user.email.to_s.split("@").first
+    end
+  end
+end

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -4,6 +4,9 @@
   <!-- 上は広め / 下は最小限（pb-0） / セクション間は少しゆったり -->
   <div class="relative max-w-3xl mx-auto px-6 pt-6 sm:pt-8 pb-0 space-y-5 sm:space-y-6">
 
+    <!-- ▼ ここで挨拶バーを表示（マイページ限定） -->
+    <%= render "shared/greeting", user: current_user %>
+
     <% title_text, kind = fasting_hero(current_user) %>
 
     <!-- ステータスメッセージ：視認性は保ちつつ高さ控えめ -->

--- a/app/views/shared/_greeting.html.erb
+++ b/app/views/shared/_greeting.html.erb
@@ -1,0 +1,9 @@
+<!-- app/views/shared/_greeting.html.erb -->
+<% if (defined?(user_signed_in?) && user_signed_in?) || local_assigns[:user].present? %>
+  <% u = local_assigns[:user] || (defined?(current_user) ? current_user : nil) %>
+  <div class="mx-auto max-w-3xl px-6 pt-3 sm:pt-4 pb-1"> <!-- 余白だけ -->
+    <p class="text-lg sm:text-xl text-gray-800 text-center font-bold">
+      こんにちは、<span class="font-bold"><%= display_name(u) %></span>さん！
+    </p>
+  </div>
+<% end %>


### PR DESCRIPTION
## 変更内容
- マイページに挨拶バーを追加（中央寄せ・太字、背景なし）
- `display_name` ヘルパーを追加（`name` 未設定時は `email` の @ 前を表示）
- `app/views/mypages/show.html.erb` で挨拶パーシャルを呼び出し

**変更ファイル**
- `app/helpers/users_helper.rb`（`display_name` 追加）
- `app/views/shared/_greeting.html.erb`（新規）
- `app/views/mypages/show.html.erb`（パーシャル呼び出しを追加）

## 背景 / 目的
- 画面遷移図に合わせ、ログイン後のマイページ冒頭に「こんにちは、○○さん！」を常時表示して親しみやすさを向上。

## スクリーンショット
**Before**
<img width="1230" height="717" alt="スクリーンショット 2025-10-14 15 38 22" src="https://github.com/user-attachments/assets/3eeef7b5-5a82-431c-9a58-952964115406" />


**After**
<img width="1231" height="716" alt="スクリーンショット 2025-10-14 16 20 11" src="https://github.com/user-attachments/assets/e1bd4786-135a-48ee-9963-95c11c56601e" />


## 動作確認
- [ ] ログイン後、マイページの先頭に「こんにちは、<ユーザー名>さん！」が**中央・太字**で表示される
- [ ] 背景の色差・下線が出ない
- [ ] `name` が空のユーザーでは `email` の @ 前が表示される
- [ ] 他ページには表示されない（マイページ限定）

## 影響範囲
- 表示のみ（スタイル・レイアウトの軽微な追加）。既存機能への副作用はなし。

## 備考
- 全ページ共通の挨拶表示は別Issueで検討予定。
## 関連
- **Refs #77**（このPRでは「挨拶」のみ対応。初回/2回目以降の表示・最終断食日・本日・目標選択UIは別PRで対応予定）
