### PR TITLE
コメント編集時のエラーを修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,12 @@ Rails.application.routes.draw do
   resources :fasting_records, only: %i[index show new create edit update destroy] do
     post :start,  on: :collection   # POST /fasting_records/start
     post :finish, on: :member       # POST /fasting_records/:id/finish
+
+    # ▼ コメント専用編集・更新
+    member do
+      get   :edit_comment          # GET   /fasting_records/:id/edit_comment
+      patch :update_comment        # PATCH /fasting_records/:id/update_comment
+    end
   end
 
   # --- 瞑想リンク（MVPは外部リンク一覧のみ） ---


### PR DESCRIPTION
- user_id の一意性バリデーションに if: :running? を追加
- コメントのみ編集時にエラーが出ないように修正
- 不要なルーティングを整理
##概要
コメント編集時に user_id の一意性バリデーションが発火してしまい、コメントのみの更新でもエラーが出ていた問題を修正しました。
編集後はエラーなく保存でき、詳細画面にリダイレクトされるようになりました。

## Before（問題点）
コメント編集フォームで「保存」ボタンを押すと
user_id taken のエラーが表示される

コメントのみ編集しても更新できなかった
<img width="1228" height="715" alt="スクリーンショット 2025-10-19 14 40 33" src="https://github.com/user-attachments/assets/e8b1f465-a267-4410-8a35-594bfb064398" />

## After（修正後）
コメントのみ編集しても正常に保存可能

詳細画面にリダイレクト＋フラッシュメッセージ表示

他のロジックへの影響なし
<img width="1224" height="720" alt="スクリーンショット 2025-10-19 14 54 03" src="https://github.com/user-attachments/assets/36a75626-1751-4874-be86-66774afe564e" />

## 変更内容
app/models/fasting_record.rb

validates :user_id に if: :running? を追加し、終了済みレコードのコメント更新時にバリデーションが発火しないよう修正

app/controllers/fasting_records_controller.rb

コメント更新後に詳細画面へリダイレクト

config/routes.rb

不要だったコメント専用ルートは利用せず、通常の edit / update に統一

RuboCop クリーンアップ（offenses 0）

## テスト
 終了済みレコードのコメント編集が正常に通ることを確認

 フラッシュメッセージとリダイレクトの挙動確認

 RuboCop 実行 → 0 offenses
Closes #81 
