### PR TITLE
feat: マイページのタイマーカード右下リンクを「瞑想で心を整える」に変更

### DIFF
--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -36,7 +36,9 @@
         </div>
         <div class="text-sm text-gray-600">開始：<%= l @running.start_time %></div>
         <div class="text-right">
-          <%= link_to "記録一覧へ", fasting_records_path, class: "text-blue-600 underline text-sm" %>
+          <%= link_to "瞑想で心を整える",
+                      meditations_path,
+                      class: "text-sky-600 underline text-sm font-semibold" %>
         </div>
       </div>
 


### PR DESCRIPTION
## 概要
マイページのタイマーカード右下リンクを、画面遷移図に合わせて「瞑想で心を整える」へ変更し、/meditations に遷移するようにしました。

## 変更内容
- 「記録一覧へ」→「瞑想で心を整える」に文言変更
- 遷移先：meditations_path（MeditationsController#index）

## スクリーンショット
- Before
<img width="1230" height="718" alt="スクリーンショット 2025-10-19 15 10 25" src="https://github.com/user-attachments/assets/d19f8e85-0871-4707-b916-b2544fd969f2" />

-  After 
<img width="1229" height="718" alt="スクリーンショット 2025-10-19 15 21 50" src="https://github.com/user-attachments/assets/0315cc12-bd57-4364-9762-827560e51d9f" />

## テスト
- [x] ログイン後マイページでリンク押下時に瞑想ページへ遷移
- [x] RuboCop 0 offenses
