### PR TITLE
build: Tailwind を Sass から分離し、application.css を manifest 化

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,0 +1,4 @@
+/*
+ *= require_tree .
+ *= require_self
+ */

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,2 +1,0 @@
-/* Keep me for dartsass-rails. Tailwind is built separately via application.tailwind.css */
-:root { --dummy: 0}

--- a/app/assets/stylesheets/tailwind.css
+++ b/app/assets/stylesheets/tailwind.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";


### PR DESCRIPTION
変更内容

Tailwind と Sass を分離し、application.css を Sprockets マニフェストとして再構成

application.scss → application.css に変更

tailwind.css を独立ファイルとして追加し、SassC によるパースを回避

デプロイ時の SassC::SyntaxError（@media (width >= 40rem)）対策

🛠 背景

Tailwind v4 の範囲メディアクエリが SassC の圧縮処理に対応していなかったため、
Render でのビルド時にエラーが発生していました。
Sass 経由ではなく、CSSとして読み込む構成に変更することでこの問題を回避します。

✅ 今後の注意点

Tailwind ファイルは .scss から @import しないこと

CSS compressor の設定を nil にすることで、範囲メディアクエリにも対応可能