### PR TITLE
fix: ログイン画面を含むフッター位置のズレを解消

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,18 +8,16 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <!-- CSS: Tailwind → application → drawer（後ろほど優先される） -->
-    <%= stylesheet_link_tag "tailwind",    "data-turbo-track": "reload" %>
+    <%# CSS は application.css（manifest）だけを読み込む %>
+    <%# application.css 側で `*= require tailwind`, `*= require landing`, `*= require drawer` の順に指定 %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= stylesheet_link_tag "drawer",      "data-turbo-track": "reload" %>
 
-    <!-- ページ個別の追加タグがあればここに -->
     <%= yield :head %>
 
-    <!-- JS(importmap): これだけでOK（application も読み込まれる） -->
+    <%# importmap を使う場合はこれだけでOK %>
     <%= javascript_importmap_tags %>
 
-    <!-- PWA/アイコン -->
+    <%# PWA / Icons %>
     <link rel="manifest" href="/manifest.json">
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
@@ -30,20 +28,25 @@
 
   <body
     data-controller="menu"
-    class="text-gray-900 min-h-dvh flex flex-col <%= 'landing-root' if landing %>"
+    class="min-h-dvh flex flex-col text-gray-900 <%= 'landing-root' if landing %>"
     style="<%= "--hero-bg: url('#{asset_path('landing/hero.jpg')}')" if landing %>">
 
     <%= render "shared/header" %>
 
+    <%# ログイン後のみドロワー %>
     <%= render("shared/menu_drawer") if user_signed_in? %>
 
-    <main class="grow mt-0 flow-root">
+    <%# 画面高に追従するメイン。grow で余白を占有し、footer を下に押す %>
+    <main class="grow">
       <div class="mx-auto max-w-5xl px-4">
         <%= render "shared/flash" %>
       </div>
       <%= yield %>
     </main>
 
-    <%= render "shared/footer" %>
+    <%# mt-auto でフッターを最下部へ %>
+    <footer class="mt-auto">
+      <%= render "shared/footer" %>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
## 概要
ログインページ（Devise）でフッターが画面途中に表示される問題を修正しました。  
画面高に追従する縦フレックスレイアウトへ変更し、フッターを常に最下部へ配置します。

## 変更点
- `app/views/layouts/application.html.erb`
  - `<body class="min-h-dvh flex flex-col">` に変更
  - `<main class="grow"> ... </main>` を追加して可変領域化
  - `<footer class="mt-auto">` でフッターを下端へ固定
  - CSS 読み込みを `stylesheet_link_tag "application"` のみに統一
- （前提）`application.css` をマニフェスト化  
  `*= require tailwind` → `*= require landing` → `*= require drawer` → `*= require_self`

## 背景
Sprockets の `require_tree .` による読み込み順の不定/スタイルの競合と、  
レイアウトが画面高を満たしていなかったことが原因で、フッターが途中に表示されていました。

## 動作確認
- `/users/sign_in` でフッターが常に画面最下部に表示されることを確認
- 主要ページ（トップ、マイページ等）でも崩れがないことを目視確認
- ブラウザは Chrome 最新で確認（強制リロード済み）

## 影響範囲
- アプリ全体のベースレイアウト（header/main/footer の骨格）。  
  既存の各ページは `yield` 配下のため、意図せぬレイアウト崩れは限定的です。

## レビュー観点
- レイアウトクラス（`min-h-dvh`, `flex`, `grow`, `mt-auto`）の付与位置は妥当か
- `application.css` の読み込み順（Tailwind → カスタムCSS）が維持されているか

## マージ後の手順
1. Render: **Manual Deploy → Clear build cache & deploy**
2. `/up` が 200 であること、`/users/sign_in` をハードリロードして表示確認
