### PR TITLE
fix: ログイン画面のフッター位置を安定化（sticky footer CSS 追加）

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,5 +2,6 @@
  *= require tailwind
  *= require landing
  *= require drawer
+ *= require layout
  *= require_self
  */

--- a/app/assets/stylesheets/layout.css
+++ b/app/assets/stylesheets/layout.css
@@ -1,0 +1,5 @@
+/* 画面高さいっぱい＋フッター最下部の保険 */
+html, body { height: 100%; }
+body { min-height: 100svh; display: flex; flex-direction: column; }
+main { flex: 1 1 auto; }
+footer { margin-top: auto; }


### PR DESCRIPTION
概要

Deviseのログインページなどでフッターが途中に表示される問題を解消するため、
sticky footer 用CSSを追加し、レイアウトを安定化させました。

変更点

app/assets/stylesheets/layout.css を新規追加

html, body に高さ指定

body に flex + min-height: 100svh

main に flex: 1 1 auto

footer に margin-top: auto を追加

application.css の読み込み順を統一

tailwind → landing → drawer → layout → self

before
<img width="1230" height="713" alt="スクリーンショット 2025-10-19 17 09 20" src="https://github.com/user-attachments/assets/abd48e1f-c6cb-4496-bbfb-e7c1df051a17" />

after
<img width="1230" height="722" alt="スクリーンショット 2025-10-19 17 33 13" src="https://github.com/user-attachments/assets/e424d579-94e3-4fe9-b121-4765320efbbb" />


背景

これまでは画面の高さが固定されず、コンテンツが少ないページ（特にログインページ）でフッターが中途半端な位置に表示されていました。

JSや複雑なスタイルを使わず、CSSのみでフッターを画面下に固定できるようにしています。

動作確認

/users/sign_in でフッターが常に最下部に表示されることを確認

トップページやマイページでもレイアウト崩れがないことを確認

Chrome でハードリロード済み

影響範囲

アプリ全体のレイアウト（header / main / footer 構成）

CSSの読み込み順に関わるため、他のページでも念のため確認を推奨

レビュー観点

sticky footer CSS の指定位置と読み込み順が適切か

他ページへの副作用がないか

マージ後の手順

Render ダッシュボードで
「Manual Deploy → Clear build cache & deploy」 を実行

/users/sign_in をハードリロード（Cmd + Shift + R）して確認