### PR TITLE
fix: 本番でヘッダー/フッターが見えなくなる件をCSSフォールバックで解消

### DIFF
--- a/app/assets/stylesheets/drawer.css
+++ b/app/assets/stylesheets/drawer.css
@@ -87,6 +87,28 @@ main > :first-child { margin-top: 0 !important; }
 /* 追加の強制（親が footer のときも確実に効かせたい場合） */
 footer .footer-legal-thin .legal-wrap{ justify-content: space-between !important; }
 
+/* ================================================================== */
+/* === Header / Footer: フォールバック（本番で色が消えても見える） === */
+/*  Tailwind の bg-brand-header / text-white がパージされても表示保証  */
+header.bg-brand-header,
+footer.bg-brand-header{
+  background-color: #bdb6b2 !important;  /* ブランドの薄グレー */
+  color: #fff !important;
+}
+
+/* ヘッダー内の文字やリンクも白にして可読性を担保 */
+header.bg-brand-header a,
+header.bg-brand-header nav,
+header.bg-brand-header .btn,
+header.bg-brand-header .flex{
+  color: #fff !important;
+}
+
+/* ログイン前の細い法務フッターのリンク色も白で固定（保険） */
+footer.bg-brand-header .footer-legal-thin .legal-links a{
+  color: #fff !important;
+}
+
 /* === Header: 全ページで“より控えめ”にする ====================== */
 header.bg-brand-header > div{
   padding-block: .375rem; /* 6px */


### PR DESCRIPTION
背景

本番環境で bg-brand-header が効かずヘッダー/フッターの色が透明化しているように見える事象が発生。

対応

drawer.css にて .bg-brand-header と .footer-legal-thin .legal-links a へ明示スタイルを追加

Tailwindクラスがパージされても視認性が保たれるフォールバックを付与

動作確認

開発・本番ともヘッダー/フッターが常に可視。法務リンクの色も白で表示。

影響範囲

全ページのヘッダー/未ログイン時のフッター、ログイン後のフッター（色はこれまで通り）