### PR TITLE
ヘッダー・フッターのフォールバックCSSを追加／調整（本番でも開発と同じ見た目を担保）

### DIFF
--- a/app/assets/stylesheets/drawer.css
+++ b/app/assets/stylesheets/drawer.css
@@ -89,7 +89,6 @@ footer .footer-legal-thin .legal-wrap{ justify-content: space-between !important
 
 /* ==================================================================
    Header / Footer フォールバック一式（本番で Tailwind が効かなくても崩さない）
-   - 置き場所: drawer.css の末尾付近（他ルールより後）を推奨
    ================================================================== */
 
 /* 色の保険：Tailwind の bg-brand-header / text-white がパージされても見えるように */
@@ -99,7 +98,7 @@ footer.bg-brand-header{
   color: #fff !important;
 }
 
-/* ヘッダー内のテキスト/リンク/ボタン等は白を強制（可読性担保）*/
+/* ヘッダー内のテキスト/リンク/ボタン等は白を強制（可読性担保） */
 header.bg-brand-header a,
 header.bg-brand-header nav,
 header.bg-brand-header .btn,
@@ -107,7 +106,7 @@ header.bg-brand-header .flex{
   color: #fff !important;
 }
 
-/* ログイン前の法務フッターのリンク色も白で固定（保険）*/
+/* ログイン前の法務フッターのリンク色も白で固定（保険） */
 footer.bg-brand-header .footer-legal-thin .legal-links a{
   color: #fff !important;
 }
@@ -122,7 +121,7 @@ header.bg-brand-header > div{
   align-items: center !important;        /* 縦中央 */
   gap: .75rem;
 
-  /* 高さ/余白（Tailwind の h-16 / px-4, md:px-8 相当の保険）*/
+  /* 高さ/余白（Tailwind の h-16 / px-4, md:px-8 相当の保険） */
   height: 64px;
   min-height: 64px;
   padding-inline: 16px;
@@ -139,33 +138,61 @@ header.bg-brand-header nav{
   gap: 1.25rem;                           /* 20px */
 }
 
-/* リンクの基本挙動（下線は hover 時だけ）*/
-header.bg-brand-header a{
-  text-decoration: none;
-}
-header.bg-brand-header a:hover{
-  text-decoration: underline;
-}
+/* リンクの基本挙動（下線は hover 時だけ） */
+header.bg-brand-header a{ text-decoration: none; }
+header.bg-brand-header a:hover{ text-decoration: underline; }
 
 /* （保険）ヘッダー内のアイテムは縦中央に */
 header.bg-brand-header .btn,
-header.bg-brand-header .flex{
-  align-items: center;
-}
+header.bg-brand-header .flex{ align-items: center; }
 
-/* ==================================================================
-   既存の “控えめヘッダー” 調整（高さだけ残す）
-   ※ 上のレイアウト保険より前に書かれている場合を想定して
-   ================================================================== */
-header.bg-brand-header > div{
-  padding-block: .375rem; /* 6px */
-}
+/* 既存の“控えめヘッダー”の高さだけ残す（上書き順対策） */
+header.bg-brand-header > div{ padding-block: .375rem; }
 @media (min-width: 640px){
   header.bg-brand-header > div{ padding-block: .5rem; }
 }
 @media (min-width: 768px){
   header.bg-brand-header > div{ padding-block: .5rem; }
 }
+
+/* ==================================================================
+   Logged-out header (landing only): compact + bold logo
+   ※ 未ログイン時だけ開発環境の見た目に寄せる
+   ================================================================== */
+
+/* ランディングのヘッダーを“やや細め”に */
+body.landing-root header.bg-brand-header > div{
+  height: 56px;              /* 3.5rem：細め */
+  min-height: 56px;
+  padding-block: .25rem !important;  /* 既存のpadding-blockを上書き */
+}
+
+/* 左のロゴ「Fasty」：太く・少し大きめ */
+body.landing-root header.bg-brand-header a span{
+  font-weight: 800;                                  /* しっかり太く */
+  font-size: clamp(1.25rem, 2.2vw, 1.75rem);         /* 20px〜28px */
+  letter-spacing: .02em;
+  color: #fff !important;
+}
+
+/* 右の「ログイン」を右端に・白文字・hoverで下線 */
+body.landing-root header.bg-brand-header nav{
+  margin-left: auto !important;
+  display: flex !important;
+  align-items: center !important;
+  gap: 1.25rem;
+}
+body.landing-root header.bg-brand-header nav a{
+  color: #fff !important;
+  text-decoration: none;
+  opacity: .95;
+  transition: opacity .15s ease, text-decoration-color .15s ease;
+}
+body.landing-root header.bg-brand-header nav a:hover{
+  opacity: 1;
+  text-decoration: underline;
+}
+
 /* ==== Bottom App Nav（ログイン後） ===================== */
 .footer-app__nav{
   display: grid;


### PR DESCRIPTION
drawer.css にフォールバック色/レイアウトを追加し、本番でもヘッダー/フッターが確実に表示されるようにしました

未ログイン時ヘッダーを細め＆ロゴ太めに調整（開発環境の見た目に合わせる）

影響範囲：全ページ共通ヘッダー／フッター（未ログイン／ログイン後）