### PR TITLE
ボタンスタイルを整理：drawer.cssに .btn 系を追加し各画面で反映

### DIFF
--- a/app/assets/stylesheets/drawer.css
+++ b/app/assets/stylesheets/drawer.css
@@ -379,3 +379,57 @@ a.btn-x{
 }
 a.btn-x:hover{ background:#222; opacity:.95; }
 a.btn-x svg{ width:18px; height:18px; }
+/* ===== Buttons (legacy utility) ===== */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: .5rem;
+  padding: .75rem 1.25rem;
+  border-radius: .5rem;           /* rounded-md 相当 */
+  font-weight: 600;
+  line-height: 1.25;
+  text-decoration: none;
+  cursor: pointer;
+  border: 1px solid transparent;
+  color: #fff;
+  background-color: #334155;      /* slate-700 相当（デフォルト） */
+  transition: background-color .2s ease, box-shadow .2s ease, transform .02s ease;
+}
+.btn:hover { background-color: #1f2937; }     /* slate-800 */
+.btn:active { transform: translateY(1px); }
+.btn:focus-visible {
+  outline: 2px solid transparent;
+  box-shadow: 0 0 0 3px rgba(59,130,246,.45); /* focus ring */
+}
+
+/* size */
+.btn-lg {
+  padding: .875rem 1.5rem;
+  font-size: 1rem;
+}
+
+/* full-width on mobile, auto on ≥640px */
+.btn-wrap { width: 100%; }
+@media (min-width: 640px) {
+  .btn-wrap { width: auto; }
+}
+
+/* variants */
+.btn-primary {
+  background-color: #2563eb;                /* blue-600 */
+  border-color: #2563eb;
+}
+.btn-primary:hover { background-color: #1d4ed8; }  /* blue-700 */
+
+.btn-danger {
+  background-color: #dc2626;                /* red-600 */
+  border-color: #dc2626;
+}
+.btn-danger:hover { background-color: #b91c1c; }   /* red-700 */
+
+/* disabled */
+.btn[disabled], .btn:disabled {
+  opacity: .6;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## 目的
- デプロイ後に効かなくなっていたボタンの見た目を復旧・統一するため

## 変更点
- `app/assets/stylesheets/drawer.css` に以下のスタイルを追加/整理
  - `.btn`, `.btn-primary`, `.btn-danger`, `.btn-lg`, `.btn-wrap` など共通クラス
- Tailwind v4 環境下でも競合しないようにセレクタの優先度と記法を調整

## 動作確認
1. 開発環境を起動
2. マイページで「ファスティング開始 / 終了」ボタンの見た目を確認
3. ハンバーガーメニュー内のリンクホバー/タップ時のスタイルを確認
4. DevTools の Network > CSS で `drawer-*.css` が 200 で読み込まれていることを確認

## リスク・備考
- 他画面の独自ボタンに影響する可能性があるため、主要画面の目視確認をお願いします
- 必要なら `layout.css` へ最小限の共通化を今後検討
