### PR TITLE
ドロワー背景をヘッダーと統一（CSS変数 --header-bg 導入）

### DIFF
--- a/app/assets/stylesheets/drawer.css
+++ b/app/assets/stylesheets/drawer.css
@@ -6,7 +6,10 @@
   transform: translateX(-100%);
   transition: transform .2s ease-out;
   z-index: 60 !important;
+  background: var(--header-bg) !important;
 }
+#site-drawer, #site-drawer a { color: #fff !important; }
+
 .menu-open #site-drawer{ transform: translateX(0) !important; }
 
 .menu-overlay{
@@ -94,7 +97,7 @@ footer .footer-legal-thin .legal-wrap{ justify-content: space-between !important
 /* 色の保険：Tailwind の bg-brand-header / text-white がパージされても見えるように */
 header.bg-brand-header,
 footer.bg-brand-header{
-  background-color: #bdb6b2 !important;   /* ブランド薄グレー */
+  background-color: var(--header-bg) !important;
   color: #fff !important;
 }
 

--- a/app/assets/stylesheets/layout.css
+++ b/app/assets/stylesheets/layout.css
@@ -3,3 +3,8 @@ html, body { height: 100%; }
 body { min-height: 100svh; display: flex; flex-direction: column; }
 main { flex: 1 1 auto; }
 footer { margin-top: auto; }
+
+/* ===== 共通カラー変数 ===== */
+:root{
+  --header-bg: #bdb6b2; /* ヘッダーのブランド薄グレー */
+}


### PR DESCRIPTION
説明

layout.css に共通色変数 --header-bg を定義

ヘッダー／フッターの背景色指定を var(--header-bg) に置き換え

drawer.css の #site-drawer に background: var(--header-bg) を追加

ドロワー内の文字色を白にフォールバック（可読性のため）

変更ファイル

app/assets/stylesheets/layout.css

app/assets/stylesheets/drawer.css

動作確認

 トップ／マイページでヘッダーとドロワーの背景色が同じになる

 ドロワー開閉時のアニメーションは従来通り

 文字色が背景と十分なコントラスト（白）