### PR TITLE
Devise 画面の専用CSSを追加して共通デザインを適用

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -4,18 +4,15 @@
 //= link_tree ../images
 
 // Tailwind v4 の出力（tailwindcss:build が生成する app/assets/builds/tailwind.css）
-//// まとめて拾うなら:
-////   //= link_tree ../builds .css
 //= link tailwind.css
 
-// 自作CSS（app/assets/stylesheets 配下をまるっとプリコンパイル）
-//// 明示で個別指定したい場合は link を並べてもOK。
-//= link_directory ../stylesheets .css
-// = link application.css
-// = link drawer.css
-// = link layout.css
-// = link landing.css
+// 自作CSS（読み込むものを明示的に列挙）
+/*= link application.css */
+/*= link drawer.css */
+/*= link layout.css */
+/*= link landing.css */
+/*= link devise.css */
 
-//（必要なら）JS バンドルを拾う
+// JS バンドル
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js

--- a/app/assets/stylesheets/devise.css
+++ b/app/assets/stylesheets/devise.css
@@ -1,0 +1,95 @@
+/* ==========================================================
+   Devise pages fallback styles（Tailwindが無くても崩さない）
+   対象: sessions/new, registrations/new, passwords/new|edit など
+   ========================================================== */
+
+:root{
+  --brand-header: #bdb6b2;        /* ヘッダーと同じ薄グレー */
+  --accent: #1e66f5;              /* ボタン青（Tailwind: blue-600 相当） */
+  --accent-press: #1453c8;
+  --panel-bg: rgba(255,255,255,.85);
+  --panel-br: 12px;
+  --panel-shadow: 0 6px 24px rgba(0,0,0,.08);
+  --field-br: 10px;
+  --field-bd: 1px solid rgba(0,0,0,.12);
+  --field-h: 44px;
+}
+
+/* 全体の最大幅とセンター配置 */
+.devise-wrap{
+  max-width: 720px;
+  margin-inline: auto;
+  padding: 24px 20px 40px;
+}
+
+/* タイトル */
+.devise-title{
+  font-size: clamp(24px, 3.2vw, 36px);
+  font-weight: 700;
+  text-align: center;
+  margin: 18px 0 22px;
+  color: #111;
+}
+
+/* フォームを半透明のカードに */
+.devise-card{
+  background: var(--panel-bg);
+  border-radius: var(--panel-br);
+  box-shadow: var(--panel-shadow);
+  padding: clamp(16px, 3vw, 28px);
+  border: 1px solid rgba(0,0,0,.06);
+}
+
+/* ラベルと入力 */
+.devise-field{ margin: 14px 0; }
+.devise-label{
+  display: block;
+  font-size: 14px;
+  color: #374151;
+  margin-bottom: 6px;
+}
+.devise-input{
+  width: 100%;
+  height: var(--field-h);
+  border: var(--field-bd);
+  border-radius: var(--field-br);
+  padding: 0 14px;
+  background: #fff;
+  outline: none;
+}
+.devise-input:focus{
+  box-shadow: 0 0 0 3px rgba(30,102,245,.15);
+  border-color: rgba(30,102,245,.45);
+}
+
+/* チェックボックス行 */
+.devise-check{
+  display:flex; align-items:center; gap:10px;
+  margin: 8px 0 6px;
+}
+
+/* 送信ボタン */
+.devise-submit{
+  display:block; width:min(360px, 90%); margin: 18px auto 0;
+  height: 48px; border-radius: 12px;
+  background: var(--accent); color:#fff; font-weight:700;
+  border: none; cursor: pointer;
+}
+.devise-submit:active{ background: var(--accent-press); }
+.devise-submit:disabled{ opacity:.6; cursor:not-allowed; }
+
+/* 補助リンク */
+.devise-links{
+  display:flex; flex-wrap:wrap; gap:16px;
+  justify-content:center;
+  margin: 20px 0 0;
+}
+.devise-links a{ color:#1f4b99; text-decoration: underline; }
+
+/* フッターの法務リンク行が白背景でも見えるように */
+footer .footer-legal-thin a{ color:#1f4b99 !important; }
+
+/* スマホ余白最適化 */
+@media (max-width: 480px){
+  .devise-wrap{ padding: 16px 14px 32px; }
+}

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,36 +1,32 @@
-<div class="container py-5">
-  <div class="row justify-content-center">
-    <div class="col-12 col-md-6 col-lg-5">
+<div class="devise-wrap">
+  <h1 class="devise-title">ログイン</h1>
 
-      <h2 class="text-center fw-bold mb-4">ログイン</h2>
+  <div class="devise-card">
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-      <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-        <div class="mb-3">
-          <%= f.label :email, "メールアドレス", class: "form-label" %>
-          <%= f.email_field :email, class: "form-control" %>
-        </div>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+      <div class="devise-field">
+        <label class="devise-label" for="user_email">メールアドレス</label>
+        <%= f.email_field :email, autofocus: true, class: "devise-input", id: "user_email" %>
+      </div>
 
-        <div class="mb-4">
-          <%= f.label :password, "パスワード", class: "form-label" %>
-          <%= f.password_field :password, autocomplete: "current-password", class: "form-control" %>
-        </div>
+      <div class="devise-field">
+        <label class="devise-label" for="user_password">パスワード</label>
+        <%= f.password_field :password, autocomplete: "current-password", class: "devise-input", id: "user_password" %>
+      </div>
 
-        <% if devise_mapping.rememberable? %>
-          <div class="form-check mb-4">
-            <%= f.check_box :remember_me, class: "form-check-input", id: "remember_me" %>
-            <%= f.label :remember_me, "ログイン状態を保持", class: "form-check-label" %>
-          </div>
-        <% end %>
-
-        <div class="d-grid gap-2">
-          <%= f.submit "ログイン", class: "btn btn-primary btn-lg" %>
+      <% if devise_mapping.rememberable? %>
+        <div class="devise-check">
+          <%= f.check_box :remember_me, id: "remember_me" %>
+          <%= f.label :remember_me, "ログイン状態を保持", for: "remember_me" %>
         </div>
       <% end %>
 
-      <div class="mt-3">
-        <%= render "devise/shared/links" %>
-      </div>
+      <%= f.submit "ログイン", class: "devise-submit" %>
+    <% end %>
 
+    <div class="devise-links">
+      <%= render "devise/shared/links" %>
     </div>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
     <%= csp_meta_tag %>
 
     <%# --- CSS: Tailwind + application（@importで自作CSSを束ねる） --- %>
-    <%= stylesheet_link_tag "tailwind", "application", "layout", "drawer", "landing", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag "tailwind", "application", "layout", "drawer", "landing", "device", "data-turbo-track": "reload" %>
 
     <%# 画面個別で <head> 追記したい時に使う %>
     <%= yield :head %>


### PR DESCRIPTION
## 目的
- ログイン/新規登録/パスワード再設定など Devise 画面の見た目を統一し、Tailwind の有無に左右されないフォールバックを提供するため

## 変更点
- 新規: app/assets/stylesheets/devise.css（フォームUI、ボタン、カード、リンク等）
- 追記: app/assets/config/manifest.js に devise.css を追加
- 変更: application.html.erb にて devise を読み込むよう更新
- 変更: devise/sessions/new.html.erb を新クラス（.devise-*）でマークアップ

## 動作確認
- /users/sign_in でフォームのレイアウト/スタイルが適用される
- Network > CSS に devise-*.css が 200 で読み込まれる
- モバイル幅で余白/可読性が保たれる

## 影響範囲
- Devise 画面（ログイン／将来的に新規登録・パスワード系にも適用予定）
