### PR TITLE
Feat: 新規登録フォームに「お名前」入力欄を追加

### DIFF
--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -7,16 +7,27 @@
     <%= render "users/shared/error_messages", resource: resource %>
 
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { data: { turbo: false } }) do |f| %>
+      <!-- お名前 -->
+      <div class="devise-field">
+        <%= f.label :name, t('activerecord.attributes.user.name'), class: "devise-label" %>
+        <%= f.text_field :name,
+              class: "devise-input",
+              autofocus: true,
+              autocomplete: "name",
+              spellcheck: false %>
+      </div>
+
+      <!-- メールアドレス -->
       <div class="devise-field">
         <%= f.label :email, t('activerecord.attributes.user.email'), class: "devise-label" %>
         <%= f.email_field :email,
               class: "devise-input",
-              autofocus: true,
               autocomplete: "email",
               inputmode: "email",
               spellcheck: false %>
       </div>
 
+      <!-- パスワード -->
       <div class="devise-field">
         <%= f.label :password, t('activerecord.attributes.user.password'), class: "devise-label" %>
         <% if @minimum_password_length.present? %>
@@ -27,6 +38,7 @@
               autocomplete: "new-password" %>
       </div>
 
+      <!-- パスワード（確認） -->
       <div class="devise-field">
         <%= f.label :password_confirmation, t('activerecord.attributes.user.password_confirmation'), class: "devise-label" %>
         <%= f.password_field :password_confirmation,


### PR DESCRIPTION
## 概要
- 新規登録（/users/sign_up）に「お名前」入力欄を追加し、User.name へ保存できるようにしました。
- Strong Parameters は既に ApplicationController で許可済みです（:sign_up / :account_update）。

Refs #110 

## 変更点
- add: app/views/users/registrations/new.html.erb に name フィールドを追加
  - ラベル: I18n `activerecord.attributes.user.name` を使用
  - 入力補助: `autocomplete="name"` / `spellcheck=false`

## 動作確認
1. `/users/sign_up` を開くと「お名前」欄が表示される
2. 「お名前・メール・パスワード」を入力→登録が成功する
3. DB（User）に name が保存される
4. 未入力で送信すると「お名前を入力してください」の日本語エラーが表示される

## スクリーンショット
before
<img width="1231" height="720" alt="スクリーンショット 2025-10-20 23 53 05" src="https://github.com/user-attachments/assets/f6786a7a-f856-4c6f-b745-74e988bbb117" />

after
- 追加後の新規登録フォーム
<img width="1229" height="719" alt="スクリーンショット 2025-10-20 23 51 58" src="https://github.com/user-attachments/assets/011bb78a-5d78-417d-b0e3-572b0e39595b" />

## リスク・影響範囲
- 低（ビューの追記のみ。既存のフローに破壊的変更なし）
