### PR TITLE
レスポンシブ基盤: ヘッダー/フッター/ドロワー対応

### DIFF
--- a/app/assets/stylesheets/drawer.css
+++ b/app/assets/stylesheets/drawer.css
@@ -1,17 +1,28 @@
-/* Drawer / Overlay — 強制固定＆縦いっぱい（Tailwindと競合しても勝つ） */
+/* Drawer / Overlay — 固定＆全高 */
 #site-drawer{
   position: fixed !important;
   top: 0 !important; bottom: 0 !important; left: 0 !important;
   height: 100svh !important;
+  /* ← 幅を「コンテンツ基準 + 上限つき」に */
+  inline-size: max-content;                          /* 中身に合わせる */
+  max-inline-size: clamp(260px, 72vw, 360px);        /* 端末に応じて自然な上限 */
+  /* 余白：safe-area も考慮 */
+  padding: calc(env(safe-area-inset-top, 0px) + 16px) 20px
+           calc(env(safe-area-inset-bottom, 0px) + 20px);
+  /* 見た目/使い勝手 */
+  overflow-y: auto; -webkit-overflow-scrolling: touch;
+  border-right: 1px solid rgba(255,255,255,.15);
+  background: var(--header-bg) !important;
+  color: #fff !important;
+  /* アニメーション */
   transform: translateX(-100%);
   transition: transform .2s ease-out;
   z-index: 60 !important;
-  background: var(--header-bg) !important;
 }
-#site-drawer, #site-drawer a { color: #fff !important; }
 
 .menu-open #site-drawer{ transform: translateX(0) !important; }
 
+/* オーバーレイ */
 .menu-overlay{
   position: fixed !important; inset: 0 !important;
   background: rgba(0,0,0,.5);
@@ -28,6 +39,11 @@
 /* 念のため：main の謎の上マージン消し */
 main { margin-top: 0 !important; padding-top: 0 !important; }
 main > :first-child { margin-top: 0 !important; }
+
+/* ========= オプション（中身のリンクが横幅を広げ過ぎないように） ======== */
+/* ドロワー内のリスト/リンクが 100% 幅で広がるレイアウトなら、max-content に寄せる */
+#site-drawer nav a{ display: inline-flex; inline-size: max-content; }
+#site-drawer nav{ display: grid; gap: 20px; }
 
 /* ==== Logged-out legal footer (ultra thin) ========================= */
 .footer-legal-thin{
@@ -228,6 +244,31 @@ body.landing-root header.bg-brand-header nav a:hover{
 .footer-app__link:hover svg{ transform: translateY(-1px); color:#000; }
 .footer-app__link.is-active svg{ color:#fff; filter: drop-shadow(0 2px 8px rgba(0,0,0,.25)); }
 .footer-app__link.is-active span{ color:#fff; font-weight:700; }
+/* ==== App Footer（ログイン後）: safe-area & タップしやすさ ================= */
+.footer-app{
+  padding-block: .5rem; /* ≒ py-2 */
+  /* iOS 下部安全域を考慮 */
+  padding-bottom: calc(.5rem + env(safe-area-inset-bottom, 0px));
+  min-height: 52px;
+}
+
+.pb-safe{
+  /* utility 代替：安全域だけ欲しい所にクラスで適用 */
+  padding-bottom: calc(env(safe-area-inset-bottom, 0px) + 0px);
+}
+
+/* フォーカスリング（キーボード操作のアクセシビリティ） */
+.footer-app__link:focus-visible{
+  outline: 2px solid rgba(255,255,255,.9);
+  outline-offset: 3px;
+  border-radius: 12px;
+}
+
+/* 端末幅が極小の時はアイコン群の間隔をやや詰める */
+@media (max-width: 360px){
+  .footer-app__nav{ gap: 1.25rem; }
+}
+
 
 /* ====== 記録詳細ページ ====== */
 

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,27 +1,27 @@
 <!-- app/views/shared/_footer.html.erb -->
 <% if user_signed_in? %>
-  <!-- ログイン後：ボトムナビ -->
+  <!-- ログイン後：ボトムナビ（safe-area対応 & アクセシビリティ強化） -->
   <footer class="bg-brand-header text-white">
-    <div class="footer-app footer-thick mx-auto max-w-[1200px] px-4 md:px-6">
-      <nav class="footer-app__nav" aria-label="アプリフッター">
+    <div class="footer-app footer-thick mx-auto max-w-[1200px] px-4 md:px-6 pb-safe">
+      <nav class="footer-app__nav" aria-label="アプリフッター・メインナビゲーション" role="navigation">
 
         <!-- 記録一覧 -->
         <%= link_to (respond_to?(:fasting_records_path) ? fasting_records_path : "#"),
           class: "footer-app__link #{(respond_to?(:fasting_records_path) && current_page?(fasting_records_path)) ? 'is-active' : ''}",
-          aria: { label: "記録一覧" } do %>
-          <svg viewBox="0 0 24 24" aria-hidden="true">
+          aria: { label: "記録一覧", current: ((respond_to?(:fasting_records_path) && current_page?(fasting_records_path)) ? 'page' : nil) } do %>
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
             <path d="M15.232 5.232a2.5 2.5 0 0 1 3.536 3.536l-8.5 8.5-4.268.732.732-4.268 8.5-8.5Z M4 20h16v2H4z" fill="currentColor"/>
           </svg>
           <span>記録一覧</span>
         <% end %>
 
-        <!-- 瞑想（B. ロータス：花びら風） -->
+        <!-- 瞑想 -->
         <%= link_to (respond_to?(:meditations_path) ? meditations_path : "#"),
           class: "footer-app__link #{(respond_to?(:meditations_path) && current_page?(meditations_path)) ? 'is-active' : ''}",
-          aria: { label: "瞑想" } do %>
-          <svg viewBox="0 0 24 24" aria-hidden="true">
+          aria: { label: "瞑想", current: ((respond_to?(:meditations_path) && current_page?(meditations_path)) ? 'page' : nil) } do %>
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
             <path d="M12 4.8c2.0 2.2 3.0 4.2 3.0 6.0c-1.6.8-3.0.8-3.0.8s-1.4 0-3.0-.8c0-1.8 1.0-3.8 3.0-6.0Z"
-                  fill="none" stroke="currentColor" stroke-width="2.0" stroke-linejoin="round"/>
+                  fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
             <path d="M6.5 7.4c.9 2.2 2.4 3.7 4.6 4.7c-2.3.8-4.2.7-6.1-.1c.1-1.7.6-3.2 1.5-4.6Z"
                   fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"/>
             <path d="M17.5 7.4c-.9 2.2-2.4 3.7-4.6 4.7c2.3.8 4.2.7 6.1-.1c-.1-1.7-.6-3.2-1.5-4.6Z"
@@ -35,8 +35,8 @@
         <!-- マイページ -->
         <%= link_to (respond_to?(:mypage_path) ? mypage_path : "#"),
           class: "footer-app__link #{(respond_to?(:mypage_path) && current_page?(mypage_path)) ? 'is-active' : ''}",
-          aria: { label: "マイページ" } do %>
-          <svg viewBox="0 0 24 24" aria-hidden="true">
+          aria: { label: "マイページ", current: ((respond_to?(:mypage_path) && current_page?(mypage_path)) ? 'page' : nil) } do %>
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
             <path d="M12 12a5 5 0 1 0-5-5 5 5 0 0 0 5 5Zm-8 8a8 8 0 0 1 16 0v1H4z" fill="currentColor"/>
           </svg>
           <span>マイページ</span>
@@ -47,15 +47,14 @@
   </footer>
 
 <% else %>
-  <!-- ログイン前：極細・法務リンクのみ -->
+  <!-- ログイン前：極細・法務リンクのみ（safe-area対応） -->
   <footer class="bg-brand-header text-white">
     <div class="footer-legal-thin mx-auto max-w-[1200px] px-4 md:px-6 pb-safe">
-      <!-- ここで flex/justify-between を“マークアップで”指定 -->
       <div class="legal-wrap flex items-center justify-between gap-3 sm:gap-4 w-full">
         <p class="copyright select-none whitespace-nowrap text-[0.8rem] leading-none opacity-95">
           &copy; <%= Time.zone.now.year %> Fasty
         </p>
-        <nav class="legal-links ml-auto flex items-center gap-3 sm:gap-5 whitespace-nowrap" aria-label="法務リンク">
+        <nav class="legal-links ml-auto flex items-center gap-3 sm:gap-5 whitespace-nowrap" aria-label="法務リンク" role="navigation">
           <%= link_to "健康と安全", health_notice_path, class: "opacity-95 hover:opacity-100 hover:underline" %>
           <%= link_to "利用規約", (respond_to?(:terms_path) ? terms_path : "#"), class: "opacity-95 hover:opacity-100 hover:underline" %>
           <%= link_to "お問い合わせ", (respond_to?(:contact_path) ? contact_path : "#"), class: "opacity-95 hover:opacity-100 hover:underline" %>
@@ -65,4 +64,3 @@
     </div>
   </footer>
 <% end %>
-

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="sticky top-0 z-50 h-16 bg-brand-header text-white shadow-sm">
+<header class="sticky top-[env(safe-area-inset-top)] z-50 h-16 bg-brand-header text-white shadow-sm">
   <div class="mx-auto max-w-[1200px] h-16 px-4 md:px-8 flex items-center gap-3">
 
     <!-- 左：ロゴ -->
@@ -9,21 +9,23 @@
     <% end %>
 
     <% if user_signed_in? %>
-      <!-- ロゴ右：メニュー（トグル） -->
-      <button type="button"
-        class="ml-2 rounded ring-1 ring-white/20 hover:ring-white/40 focus:outline-none focus:ring-2 focus:ring-white/60"
-        style="display:inline-flex;align-items:center;justify-content:center;width:32px;height:32px;flex:none"
+      <!-- モバイル：メニュートグル（md以上は非表示） -->
+      <button
+        type="button"
+        class="ml-2 md:hidden inline-flex items-center justify-center size-10 rounded-xl ring-1 ring-white/20
+               hover:ring-white/40 focus:outline-none focus:ring-2 focus:ring-white/60"
         data-menu-target="button" data-action="click->menu#toggle"
         aria-controls="site-drawer" aria-expanded="false" aria-label="メニュー">
-        <span aria-hidden="true" style="position:relative;display:block;width:18px;height:14px">
-          <span style="position:absolute;left:0;right:0;top:0;height:2px;background:#fff;border-radius:9999px"></span>
-          <span style="position:absolute;left:0;right:0;top:50%;transform:translateY(-50%);height:2px;background:#fff;border-radius:9999px"></span>
-          <span style="position:absolute;left:0;right:0;bottom:0;height:2px;background:#fff;border-radius:9999px"></span>
-        </span>
+        <!-- ハンバーガーアイコン（stroke で描画して表示されるように修正） -->
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
+             class="w-5 h-5" aria-hidden="true" focusable="false" fill="none">
+          <path d="M3 6h18M3 12h18M3 18h18"
+                stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+        </svg>
       </button>
     <% end %>
 
-    <!-- 右：ログイン時は何も出さない。未ログイン時のみ「ログイン」 -->
+    <!-- 右：未ログイン時のみナビ（ログイン） -->
     <nav class="ml-auto flex items-center gap-6">
       <% unless user_signed_in? %>
         <%= nav_link_to "ログイン", new_user_session_path %>

--- a/app/views/shared/_menu_drawer.html.erb
+++ b/app/views/shared/_menu_drawer.html.erb
@@ -1,61 +1,60 @@
-<%# app/views/shared/_menu_drawer.html.erb %>
-
 <%# ▼ 左ドロワー（縦長パネル） %>
 <div id="site-drawer"
      data-menu-target="drawer"
      data-action="keydown.esc@window->menu#close"
-     class="fixed inset-y-0 left-0 w-72 md:w-80 max-w-[86vw]
+     class="fixed inset-y-0 left-0
+            /* ← 幅はCSS側の clamp / max-content に任せる */
             -translate-x-full transform
             bg-brand-header text-white shadow-xl
             transition-transform duration-200 ease-out will-change-transform z-[60]"
      role="dialog" aria-modal="true" aria-label="メニュー" tabindex="-1">
 
   <div class="h-14 px-4 md:px-5 flex items-center justify-between border-b border-white/15">
-    <span class="text-base md:text-lg font-semibold tracking-wide">メニュー</span>
+    <span class="text-base md:text-lg font-semibold tracking-wide whitespace-nowrap">メニュー</span>
     <button class="p-2 rounded hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/60"
             data-action="click->menu#close" aria-label="閉じる">✕</button>
   </div>
 
   <nav class="px-3 md:px-4 py-4 md:py-5">
-    <ul class="space-y-1 text-white">
+    <ul class="grid gap-2 text-white">
       <li>
         <%= button_to destroy_user_session_path,
-              method: :delete, form: { class: "block" },
-              class: "w-full text-left px-3 py-2 rounded hover:bg-white/10 font-medium" do %>
+              method: :delete, form: { class: "inline" },
+              class: "inline-flex items-center px-3 py-2 rounded hover:bg-white/10 font-medium whitespace-nowrap" do %>
           ログアウト
         <% end %>
       </li>
 
       <li>
         <%= link_to (defined?(health_and_safety_path) ? health_and_safety_path : "#"),
-              class: "block px-3 py-2 rounded hover:bg-white/10" do %>
+              class: "inline-flex items-center px-3 py-2 rounded hover:bg-white/10 whitespace-nowrap" do %>
           健康と安全
         <% end %>
       </li>
 
       <li>
         <%= link_to (defined?(contact_path) ? contact_path : "#"),
-              class: "block px-3 py-2 rounded hover:bg-white/10" do %>
+              class: "inline-flex items-center px-3 py-2 rounded hover:bg-white/10 whitespace-nowrap" do %>
           お問い合わせ
         <% end %>
       </li>
 
       <li>
         <%= link_to (defined?(privacy_path) ? privacy_path : "#"),
-              class: "block px-3 py-2 rounded hover:bg-white/10" do %>
+              class: "inline-flex items-center px-3 py-2 rounded hover:bg-white/10 whitespace-nowrap" do %>
           プライバシーポリシー
         <% end %>
       </li>
 
       <li>
         <%= link_to (defined?(terms_path) ? terms_path : "#"),
-              class: "block px-3 py-2 rounded hover:bg-white/10" do %>
+              class: "inline-flex items-center px-3 py-2 rounded hover:bg-white/10 whitespace-nowrap" do %>
           利用規約
         <% end %>
       </li>
     </ul>
 
-    <div class="mt-6 px-3 text-xs opacity-80 select-none">
+    <div class="mt-6 px-3 text-xs opacity-80 select-none whitespace-nowrap">
       &copy; <%= Time.current.year %> Fasty
     </div>
   </nav>


### PR DESCRIPTION
## 目的
本リリースに向けて、シェル（ヘッダー／フッター／ドロワー）のレスポンシブ体験を底上げ。
safe-area 対応・操作性の改善・視認性の統一を含む。

## 変更点（概要）
- **ヘッダー**
  - `top:[env(safe-area-inset-top)]` でノッチ対応
  - モバイルのみハンバーガー表示（`md:hidden`）、SVG を stroke 描画に変更
  - フォーカスリング/タップ領域（≥40px）整備

- **ドロワー**
  - 幅を **コンテンツ基準＋上限** に変更  
    `inline-size: max-content; max-inline-size: clamp(260px, 72vw, 360px)`
  - safe-area パディング、慣性スクロール、閉じる操作（Esc/overlay）維持
  - メニュー項目を `inline-flex`＋`whitespace-nowrap` にして自然な横幅に

- **フッター**
  - ログイン後：ボトムナビに `pb-safe` でホームインジケータ回避
  - 現在ページに `aria-current="page"` 付与（視覚ハイライト連動）
  - 未ログイン：極細法務フッターの整列/可読性を維持

## 影響範囲
- 変更ファイル  
  - `app/assets/stylesheets/drawer.css`  
  - `app/views/shared/_header.html.erb`  
  - `app/views/shared/_footer.html.erb`  
  - `app/views/shared/_menu_drawer.html.erb`
- 画面外レイアウトには副作用なし（ページ本体は未変更）

## 動作確認
- [ ] 360/375/414/768/1024 px で崩れなし
- [ ] iOS/Android で上下 safe-area に被りなし
- [ ] ハンバーガー押下でドロワー開閉、Esc/背景タップで閉じる
- [ ] 現在ページのボトムナビが強調表示される

## スクリーンショット
（後続でまとめて添付予定）

## 関連
Refs #114
