### PR TITLE
モバイル向けフラッシュ文言を短縮（開始/終了/保存/コメント）— 1行収まり最適化

### DIFF
--- a/app/controllers/fasting_records_controller.rb
+++ b/app/controllers/fasting_records_controller.rb
@@ -39,7 +39,7 @@ class FastingRecordsController < ApplicationController
   def create
     @record = @scope.new(fasting_record_params)
     if @record.save
-      redirect_to fasting_records_path, notice: "新しい記録を登録しました"
+      redirect_to fasting_records_path, notice: "記録を追加しました"
     else
       render :new, status: :unprocessable_entity
     end
@@ -81,14 +81,14 @@ class FastingRecordsController < ApplicationController
         redirect_to long_health_notice_path(hours: hours) and return
       end
       if params[:agree_long] != "1"
-        redirect_to long_health_notice_path(hours: hours), alert: "同意チェックが必要です。" and return
+        redirect_to long_health_notice_path(hours: hours), alert: "同意が必要です。" and return
       end
     end
 
     record = @scope.new(start_time: Time.current, target_hours: hours, success: nil)
 
     if record.save
-      redirect_to mypage_path, notice: "ファスティングを開始しました"
+      redirect_to mypage_path, notice: "開始しました"
     else
       redirect_to mypage_path, alert: record.errors.full_messages.to_sentence
     end
@@ -97,7 +97,7 @@ class FastingRecordsController < ApplicationController
   # 今すぐ終了（終了時に自動で success を判定）
   def finish
     if @record.end_time.present?
-      redirect_to mypage_path, alert: "この記録はすでに終了しています。" and return
+      redirect_to mypage_path, alert: "この記録は終了済みです。" and return
     end
 
     @record.end_time = Time.current
@@ -105,7 +105,7 @@ class FastingRecordsController < ApplicationController
     @record.save!
 
     redirect_to edit_fasting_record_path(@record),
-                notice: "ファスティングを終了しました。今の気持ちをコメントしましょう"
+                notice: "終了しました。コメントをどうぞ"
   end
 
   # -----------------------------
@@ -117,9 +117,9 @@ class FastingRecordsController < ApplicationController
 
   def update_comment
     if @record.update(comment_params)
-      redirect_to @record, notice: "コメントを更新しました"
+      redirect_to @record, notice: "コメントを保存しました"
     else
-      flash.now[:alert] = "コメントを更新できませんでした"
+      flash.now[:alert] = "コメントを保存できませんでした"
       render :edit_comment, status: :unprocessable_entity
     end
   end
@@ -170,8 +170,8 @@ class FastingRecordsController < ApplicationController
     return "保存しました。" unless record.end_time.present?
 
     case record.success
-    when true  then "保存しました。達成おめでとう！🎉 いい流れ、今日は自分を褒めよう。"
-    when false then "保存しました。おつかれさま！今回は休息デー。明日に向けてリスタート！"
+    when true  then "保存しました。達成おめでとう！ "
+    when false then "保存しました。次は達成できますように！"
     else            "保存しました。"
     end
   end


### PR DESCRIPTION
## 概要
- スマホ表示時にフラッシュメッセージが折り返されないよう、文言を短縮しました。
- 対象：記録の **開始 / 終了 / 保存（更新） / コメント保存**。
- できるだけポジティブさを保ちつつ、1行に収まる長さへ最適化。

## 変更内容
- `app/controllers/fasting_records_controller.rb`
  - `create`：`新しい記録を登録しました` → **`記録を追加しました`**
  - `start`：`ファスティングを開始しました` → **`開始しました`**
  - `finish`：`ファスティングを終了しました。今の気持ちをコメントしましょう` → **`終了しました。コメントをどうぞ`**
  - `update_comment` 成功/失敗：**「コメントを保存しました / 保存できませんでした」** に統一
  - `flash_message_for`：
    - 成功時：**`保存しました。達成おめでとう！`**
    - 失敗時：**`保存しました。次は達成できますように！`**
    - それ以外：**`保存しました。`**

## ねらい
- モバイルの小画面でもフラッシュが**1行完結**し、UI のジャンプを抑制
- 絵文字や冗長表現を控え、端末差による予期せぬ改行を軽減

## 動作確認
- [x] 記録開始 → `開始しました`
- [x] 記録終了 → `終了しました。コメントをどうぞ` に遷移で表示
- [x] 記録編集保存（成功/失敗）→ `保存しました。…`
- [x] コメント保存（成功/失敗）
- [x] iPhone SE/8 相当の幅でも 1 行に収まることを目視確認
- [x] RuboCop：`no offenses detected`

## リスク・影響
- コントローラのフラッシュ文言のみ。DB/ビジネスロジックへの影響なし。

## 関連
- Refs #114 