### PR TITLE
OGP: default_metaのURLフォールバックを整形（インデント/end修正）

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -159,7 +159,6 @@ module ApplicationHelper
   def x_share_url(record)
     text = x_share_text(record)
     url  = fasting_record_url(record) # OGPでプレビューされる
-
     "https://x.com/intent/tweet?text=#{ERB::Util.url_encode(text)}&url=#{ERB::Util.url_encode(url)}"
   end
 
@@ -194,13 +193,28 @@ module ApplicationHelper
     ((record.end_time - record.start_time) / 3600.0).round(1)
   end
 
+  #========================
+  # OGP/Twitterカードの既定値
+  #========================
   def default_meta
+    base = request&.base_url || "https://#{ENV.fetch('APP_HOST', 'fasty-web.onrender.com')}"
+    home =
+      if respond_to?(:authenticated_root_url) && defined?(user_signed_in?) && user_signed_in?
+        authenticated_root_url
+      elsif respond_to?(:unauthenticated_root_url)
+        unauthenticated_root_url
+      elsif respond_to?(:root_url)
+        root_url
+      else
+        "#{base}/"
+      end
+
     {
       site_name:   "Fasty",
       title:       "Fasty — ファスティング×瞑想で内側からきれいを育てる",
       description: "断食と瞑想をやさしく続けられる記録アプリ。開始→終了→一言コメントだけのミニマル体験で、毎日の継続をサポートします。",
-      image:       image_url("ogp/fasty_ogp.png"), # 1200x630
-      url:         root_url
+      image:       image_url("ogp/fasty_ogp.png"),
+      url:         home
     }
   end
 end


### PR DESCRIPTION
## 目的
`default_meta` の `url` 生成まわりで `root_url` 未定義時に NameError を避けるため、
フォールバックロジックを追加し、合わせてインデント/`end` の整形を実施。

## 変更内容
- `app/helpers/application_helper.rb`
  - `default_meta` に安全なURLフォールバックを実装
    - `authenticated_root_url` → `unauthenticated_root_url` → `root_url` → `https://APP_HOST/` の順で解決
    - `request&.base_url` と `ENV["APP_HOST"]` を利用して絶対URLを保証
  - コード整形（インデント、`end` の対応整理）

## 背景/Context
- `Mypages#show` で `NameError: undefined local variable or method 'root_url'` が発生。
- ルーティング構成が `authenticated_root`/`unauthenticated_root` ベースのため、環境により `root_url` が存在しないケースがある。

## 動作確認
- [ ] ログイン状態/未ログイン状態で各ページ表示が正常
- [ ] Xカード用の `<meta property="og:url">` が絶対URLで出力される
- [ ] X Card Validator で `https://fasty-web.onrender.com` をプレビューし、OGP画像が表示される

## 影響範囲
- `ApplicationHelper#default_meta` のみ（他画面への破壊的変更なし）

## 追記（参考）
- 本番ホストは `config/environments/production.rb` で `APP_HOST` として参照可能
