### PR TITLE
瞑想ページのタイトル文言を変更

### DIFF
--- a/app/views/meditations/index.html.erb
+++ b/app/views/meditations/index.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-auto max-w-4xl p-4">
-  <h1 class="text-xl font-semibold">瞑想ガイド（5分/ 10分/ 20分 / 30分）</h1>
+  <h1 class="text-xl font-semibold">瞑想メニュー</h1>
   <div class="mt-4 grid gap-4 sm:grid-cols-2">
     <% @meditations.each do |m| %>
       <article class="rounded-xl border bg-white p-4">


### PR DESCRIPTION
## 概要
瞑想ページのタイトルを「瞑想ガイド」から「瞑想メニュー」に変更しました。

## 変更内容
- `app/views/meditations/index.html.erb` の h1 文言を修正

## 確認項目
- [ ] ページ上部のタイトルが「瞑想メニュー」に表示されること
- [ ] レイアウト崩れがないこと

## 関連
- Refs #43 
<img width="1232" height="720" alt="スクリーンショット 2025-10-27 15 22 14" src="https://github.com/user-attachments/assets/cfec193f-acde-45c2-a367-cc8dc436e8f8" />
