### PR TITLE
Googleログイン本番対応の安定化（Devise/OmniAuth 設定 & コールバック修正）

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -4,20 +4,58 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # /users/auth/google_oauth2/callback
   def google_oauth2
     auth = request.env["omniauth.auth"]
+
+    unless auth
+      Rails.logger.error("[OmniAuth] auth hash is nil")
+      return redirect_to new_user_session_path,
+                         alert: "Googleログインに失敗しました。（認証情報が取得できませんでした）"
+    end
+
     @user = User.from_omniauth(auth)
 
     if @user.persisted?
       set_flash_message(:notice, :success, kind: "Google") if is_navigational_format?
       sign_in_and_redirect @user, event: :authentication
     else
+      Rails.logger.error("[OmniAuth] user save failed: #{@user.errors.full_messages.join(', ')}")
       session["devise.google_data"] = auth.except("extra")
-      redirect_to new_user_registration_url,
-                  alert: @user.errors.full_messages.join("\n")
+      redirect_to new_user_session_path,
+                  alert: "Googleログインに失敗しました。もう一度お試しください。"
     end
+  rescue StandardError => e
+    backtrace = (e.backtrace || []).first(5).join("\n")
+    msg = "[OmniAuth] exception: #{e.class} #{e.message}\n#{backtrace}"
+    Rails.logger.error(msg)
+
+    redirect_to new_user_session_path,
+                alert: "Googleログインに失敗しました。時間をおいて再度お試しください。"
   end
 
+  # /users/auth/failure
   def failure
-    redirect_to new_user_session_path,
-                alert: "Googleログインに失敗しました。もう一度お試しください。"
+  err      = request.env["omniauth.error"]
+  strategy = request.env["omniauth.error.strategy"]&.name
+  type     = request.env["omniauth.error.type"]
+  reason   = params[:error_description] || params[:error_reason] || params[:error]
+
+  Rails.logger.error <<~LOG
+    [OmniAuth][failure]
+      strategy=#{strategy.inspect}
+      type=#{type.inspect}
+      reason=#{reason.inspect}
+      error_class=#{err&.class}
+      error_message=#{err&.message}
+  LOG
+
+  # デバッグ中はユーザーにも理由を軽く見せる（後で消す）
+  flash_alert = reason.presence || (type && type.to_s.humanize) || "Googleログインがキャンセルされました。"
+  redirect_to new_user_session_path, alert: flash_alert
+end
+
+
+  protected
+
+  def after_omniauth_failure_path_for(_scope)
+    new_user_session_path
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -3,52 +3,35 @@
 Devise.setup do |config|
   # == Mailer
   config.mailer_sender = ENV.fetch("DEFAULT_MAIL_FROM", "no-reply@example.com")
-  # config.mailer = 'Devise::Mailer'
-  # config.parent_mailer = 'ActionMailer::Base'
 
   # == ORM
   require "devise/orm/active_record"
 
   # == Authentication keys
-  config.case_insensitive_keys  = [ :email ]
-  config.strip_whitespace_keys  = [ :email ]
+  config.case_insensitive_keys = [ :email ]
+  config.strip_whitespace_keys = [ :email ]
 
   # == Session / Security
   config.skip_session_storage = [ :http_auth ]
-  # config.clean_up_csrf_token_on_authentication = true
 
   # == Password hashing
   config.stretches = Rails.env.test? ? 1 : 12
-  # config.pepper = '...'
 
   # == Confirmable
   config.reconfirmable = true
 
   # == Rememberable
-  # config.remember_for = 2.weeks
   config.expire_all_remember_me_on_sign_out = true
 
   # == Validatable
   config.password_length = 6..128
   config.email_regexp    = /\A[^@\s]+@[^@\s]+\z/
 
-  # == Timeoutable / Lockable（必要なら有効化）
-  # config.timeout_in       = 30.minutes
-  # config.lock_strategy    = :failed_attempts
-  # config.unlock_strategy  = :both
-  # config.maximum_attempts = 20
-  # config.unlock_in        = 1.hour
-
   # == Recoverable
-  # config.reset_password_keys = [:email]
   config.reset_password_within = 6.hours
-  # config.sign_in_after_reset_password = true
 
   # == Scoped views（users/* ビューを使う）
   config.scoped_views = true
-
-  # == Default scope
-  # config.default_scope = :user
 
   # == Sign out
   config.sign_out_via = :delete
@@ -58,37 +41,33 @@ Devise.setup do |config|
   config.responder.redirect_status = :see_other
   config.navigational_formats      = [ "*/*", :html, :turbo_stream ]
 
-  # == OmniAuth（Google）
+  # ====================== OmniAuth（Google） ======================
+  # Google Cloud Console の「承認済みのリダイレクトURI」には
+  #   - http://localhost:3000/users/auth/google_oauth2/callback（開発）
+  #   - https://fasty-web.onrender.com/users/auth/google_oauth2/callback（本番）
+  # を完全一致で登録すること。
   #
-  # Google Cloud Console の「承認済みのリダイレクト URI」には
-  #   http://localhost:3000/users/auth/google_oauth2/callback
-  # を（本番は本番URLで）**完全一致**で登録してください。
-  #
-  google_id     = ENV["GOOGLE_CLIENT_ID"]
-  google_secret = ENV["GOOGLE_CLIENT_SECRET"]
+  # 無条件でプロバイダを登録（ENVが空だと実認可は失敗するが、未登録404を防ぐ）
+  config.omniauth :google_oauth2,
+                  ENV["GOOGLE_CLIENT_ID"],
+                  ENV["GOOGLE_CLIENT_SECRET"],
+                  scope:       "email,profile",
+                  prompt:      "select_account",
+                  access_type: "offline",
+                  client_options: {
+                    authorize_url: "https://accounts.google.com/o/oauth2/v2/auth",
+                    token_url:     "https://oauth2.googleapis.com/token"
+                  }
 
-  if google_id.present? && google_secret.present?
-    config.omniauth :google_oauth2,
-                    google_id,
-                    google_secret,
-                    {
-                      scope:       "openid email profile",
-                      prompt:      "select_account",
-                      access_type: "offline",
-                      # ▼ 重要：v2 エンドポイントを明示（旧URLだと 404 になるケース対策）
-                      client_options: {
-                        authorize_url: "https://accounts.google.com/o/oauth2/v2/auth",
-                        token_url:     "https://oauth2.googleapis.com/token"
-                      }
-                    }
-  else
-    Rails.logger.warn("[Devise/OmniAuth] GOOGLE_CLIENT_ID/SECRET が未設定のため、Googleプロバイダは無効です。")
+  # 逆プロキシ(Render/Cloudflare)配下でも正しいコールバックURLを組み立てる
+  OmniAuth.config.full_host = lambda do |env|
+    scheme = (env["HTTP_X_FORWARDED_PROTO"] || env["rack.url_scheme"])
+    host   = (env["HTTP_X_FORWARDED_HOST"]  || env["HTTP_HOST"])
+    "#{scheme}://#{host}"
   end
 
-  # --- 開発時のデバッグ（任意）---
-  if Rails.env.development?
-    require "omniauth"
-    OmniAuth.config.allowed_request_methods = %i[post get]
-    OmniAuth.config.silence_get_warning     = true
-  end
+  # OmniAuth v2：リクエストはPOSTのみ許可（GETは警告＆拒否）
+  OmniAuth.config.allowed_request_methods = [ :post ]
+  OmniAuth.config.logger = Rails.logger
+  # ==============================================================
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # config/routes.rb
 Rails.application.routes.draw do
-  # Devise（users 名前空間のコントローラを使用）
+  # ===================== Devise =====================
+  # users 名前空間のコントローラを使用
   devise_for :users, controllers: {
     sessions:           "users/sessions",
     registrations:      "users/registrations",
@@ -8,24 +9,26 @@ Rails.application.routes.draw do
     omniauth_callbacks: "users/omniauth_callbacks" # Google などのコールバック
   }
 
-  # ✅ 迷いアクセス対策：/users は存在しないためログインへ誘導
+  # 迷いアクセス対策：/users は存在しないためログインへ誘導
   get "/users", to: redirect("/users/sign_in")
 
-  # 開発時のメール受信箱（/letter_opener）
+  # ===================== 開発用 =====================
   if Rails.env.development?
+    # 開発時のメール受信箱（/letter_opener）
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
 
-  # --- 健康と安全（同意フロー / 単数リソース） ---
+  # ===================== 単数系：同意フロー =====================
   resource :health_notice,
-           only: [ :show, :create ],
+           only: %i[show create],
            controller: "health_notice",
            path: "health-notice" do
     get :long
   end
 
-  # --- マイページ（ログイン後の着地点） ---
-  resource :mypage, only: :show  # /mypage -> MypagesController#show
+  # ===================== マイページ =====================
+  # /mypage -> MypagesController#show
+  resource :mypage, only: :show
 
   # ログイン状態でトップ切り替え
   authenticated :user do
@@ -38,7 +41,7 @@ Rails.application.routes.draw do
   # ランディング直アクセス（任意）
   get "pages/home", to: "pages#home", as: :pages_home
 
-  # --- ファスティング記録 ---
+  # ===================== ファスティング記録 =====================
   resources :fasting_records, only: %i[index show new create edit update destroy] do
     post :start,  on: :collection
     post :finish, on: :member
@@ -49,11 +52,17 @@ Rails.application.routes.draw do
     end
   end
 
-  # --- 瞑想リンク（MVPは外部リンク一覧のみ） ---
+  # ===================== 瞑想リンク（MVP） =====================
   resources :meditations, only: :index
 
-  # --- ヘルスチェック / PWA ---
-  get "up",                to: "rails/health#show",        as: :rails_health_check
-  get "service-worker.js", to: "rails/pwa#service_worker", as: :pwa_service_worker
-  get "manifest.json",     to: "rails/pwa#manifest",       as: :pwa_manifest
+  # ===================== ヘルスチェック =====================
+  get "up", to: "rails/health#show", as: :rails_health_check
+
+  # ===================== PWA関連 =====================
+  # NOTE:
+  #  - 現在は public/service-worker.js を直接配信する構成。
+  #  - 下記の rails/pwa ルートを有効にすると SW が差し替わるためコメントアウト。
+  #
+  # get "service-worker.js", to: "rails/pwa#service_worker", as: :pwa_service_worker
+  # get "manifest.json",     to: "rails/pwa#manifest",       as: :pwa_manifest
 end


### PR DESCRIPTION
## 概要
- Google OAuth の本番動作を安定化
- 例外/失敗時のハンドリングとログ出力を追加
- Devise 初期化で v2 エンドポイントを明示
- routes の OmniAuth 経路を整理

## 変更点
- app/controllers/users/omniauth_callbacks_controller.rb
  - 例外処理・ログ出力・failureハンドラの整理
- config/initializers/devise.rb
  - client_options（authorize_url / token_url）を v2 に固定
  - navigational_formats の明示
- config/routes.rb
  - omniauth_callbacks の指定を明確化

## 動作確認
- `bin/rails routes | grep -E "google_oauth2|omniauth"`
- 本番（Render）で環境変数を設定済み：
  - GOOGLE_CLIENT_ID
  - GOOGLE_CLIENT_SECRET
- OAuth の承認済みリダイレクトURI：
  - https://fasty-web.onrender.com/users/auth/google_oauth2/callback
- シークレットウィンドウでログイン→ `/mypage` に遷移すること

## 備考
- Testing モードでもテストユーザーに追加すれば動作可
- 一般公開する場合は OAuth 同意画面を “In production” に切替
