### PR TITLE
OmniAuth/Google: redirect_uriの明示指定を削除し、APP_HOSTベースでfull_hostを安定化（inva…

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,76 +1,88 @@
 # frozen_string_literal: true
 
 Devise.setup do |config|
-  # == Mailer
+  # Mailer
   config.mailer_sender = ENV.fetch("DEFAULT_MAIL_FROM", "no-reply@example.com")
 
-  # == ORM
+  # ORM
   require "devise/orm/active_record"
 
-  # == Authentication keys
-  config.case_insensitive_keys = [ :email ]
-  config.strip_whitespace_keys = [ :email ]
+  # Auth keys
+  config.case_insensitive_keys = [:email]
+  config.strip_whitespace_keys = [:email]
 
-  # == Session / Security
-  config.skip_session_storage = [ :http_auth ]
+  # Session / Security
+  config.skip_session_storage = [:http_auth]
 
-  # == Password hashing
+  # Password hashing
   config.stretches = Rails.env.test? ? 1 : 12
 
-  # == Confirmable
+  # Confirmable
   config.reconfirmable = true
 
-  # == Rememberable
+  # Rememberable
   config.expire_all_remember_me_on_sign_out = true
 
-  # == Validatable
+  # Validatable
   config.password_length = 6..128
   config.email_regexp    = /\A[^@\s]+@[^@\s]+\z/
 
-  # == Recoverable
+  # Recoverable
   config.reset_password_within = 6.hours
 
-  # == Scoped views（users/* ビューを使う）
+  # Scoped views
   config.scoped_views = true
 
-  # == Sign out
+  # Sign out
   config.sign_out_via = :delete
 
-  # == Hotwire / Turbo
+  # Hotwire / Turbo
   config.responder.error_status    = :unprocessable_entity
   config.responder.redirect_status = :see_other
-  config.navigational_formats      = [ "*/*", :html, :turbo_stream ]
+  config.navigational_formats      = ["*/*", :html, :turbo_stream]
 
-  # ====================== OmniAuth（Google） ======================
-  # Google Cloud Console の「承認済みのリダイレクトURI」には完全一致で以下を登録すること：
-  #   - http://localhost:3000/users/auth/google_oauth2/callback（開発）
-  #   - https://fasty-web.onrender.com/users/auth/google_oauth2/callback（本番）
-  #
-  # ENV が空でもルート未定義404を避けるために無条件登録（実行時はENV必須）
+  # ===================== OmniAuth（Google） =====================
+  # GCP 側の「承認済みのリダイレクトURI」に *完全一致* で下記を登録しておくこと
+  # - http://localhost:3000/users/auth/google_oauth2/callback   （開発）
+  # - https://<本番ドメイン>/users/auth/google_oauth2/callback  （本番）
+  require "omniauth-google-oauth2"
+
+  google_id     = ENV["GOOGLE_CLIENT_ID"]
+  google_secret = ENV["GOOGLE_CLIENT_SECRET"]
+
   config.omniauth :google_oauth2,
-                  ENV["GOOGLE_CLIENT_ID"],
-                  ENV["GOOGLE_CLIENT_SECRET"],
-                  scope:       "openid email profile",
-                  prompt:      "select_account",
-                  access_type: "offline",
-                  client_options: {
-                    authorize_url: "https://accounts.google.com/o/oauth2/v2/auth",
-                    token_url:     "https://oauth2.googleapis.com/token"
+                  google_id,
+                  google_secret,
+                  {
+                    scope:       "openid,email,profile",
+                    prompt:      "select_account",     # ← Googleの画面でアカウント選択
+                    access_type: "online",
+                    # 重要：redirect_uri は **指定しない**（環境依存のズレを防ぐ）
+                    client_options: {
+                      authorize_url: "https://accounts.google.com/o/oauth2/v2/auth",
+                      token_url:     "https://oauth2.googleapis.com/token"
+                    }
                   }
+  # =============================================================
+end
 
-  # 逆プロキシ(Render/Cloudflare)配下でも正しいコールバックURLを組み立てる
-  require "omniauth"
-  OmniAuth.config.full_host = lambda do |env|
-    scheme = (env["HTTP_X_FORWARDED_PROTO"] || env["rack.url_scheme"])
-    host   = (env["HTTP_X_FORWARDED_HOST"]  || env["HTTP_HOST"])
+# ===== OmniAuth のホスト判定（逆プロキシ対策 & 本番固定オプション）=====
+require "omniauth"
+
+# APP_HOST があればそれを最優先で利用（例: https://fasty-web.onrender.com）
+OmniAuth.config.full_host = lambda do |env|
+  if ENV["APP_HOST"].present?
+    ENV["APP_HOST"]
+  else
+    scheme = env["HTTP_X_FORWARDED_PROTO"] || env["rack.url_scheme"] || "https"
+    host   = env["HTTP_X_FORWARDED_HOST"]  || env["HTTP_HOST"]
     "#{scheme}://#{host}"
   end
-
-  # OmniAuth v2 既定は POST のみ。SW の navigation preload や直叩き GET を許容して安定化
-  OmniAuth.config.allowed_request_methods = %i[post get]
-  OmniAuth.config.silence_get_warning     = true
-
-  # ログは Rails.logger に
-  OmniAuth.config.logger = Rails.logger
-  # ==============================================================
 end
+
+# OmniAuth v2 で GET を許容（直リンクや戻る等での失敗を避ける）
+OmniAuth.config.allowed_request_methods = %i[post get]
+OmniAuth.config.silence_get_warning     = true
+
+# ロガー
+OmniAuth.config.logger = Rails.logger


### PR DESCRIPTION
## 目的
- Googleログインで発生していた `invalid_grant: Bad Request` の解消

## 変更点
- `config/initializers/devise.rb`
  - `redirect_uri:` の明示指定を削除（環境依存のズレを防ぐ）
  - `OmniAuth.config.full_host` を `APP_HOST` 優先 + 逆プロキシヘッダfallbackに
  - OmniAuth v2 で GET 許容、logger 設定

## 期待結果
- 本番(Render)で `APP_HOST` を `https://fasty-web.onrender.com` に設定済みの場合、
  認可時とトークン交換時の `redirect_uri` が一致し、`invalid_grant` が発生しない。

## 確認項目
- [ ] RenderのEnvironmentに `APP_HOST=https://fasty-web.onrender.com`
- [ ] GCPの Authorized redirect URIs に
      `https://fasty-web.onrender.com/users/auth/google_oauth2/callback` を登録済み
