### PR TITLE
Googleログイン安定化: prompt/redirect_uri をサーバ側で強制（invalid_grant対策）

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,75 +1,92 @@
 # frozen_string_literal: true
 
 Devise.setup do |config|
-  # Mailer
+  # == Mailer
   config.mailer_sender = ENV.fetch("DEFAULT_MAIL_FROM", "no-reply@example.com")
 
-  # ORM
+  # == ORM
   require "devise/orm/active_record"
 
-  # Auth keys
-  config.case_insensitive_keys = [ :email ]
-  config.strip_whitespace_keys = [ :email ]
+  # == Authentication keys
+  config.case_insensitive_keys   = [ :email ]
+  config.strip_whitespace_keys   = [ :email ]
 
-  # Session / Security
-  config.skip_session_storage = [ :http_auth ]
+  # == Session / Security
+  config.skip_session_storage    = [ :http_auth ]
 
-  # Password hashing
-  config.stretches = Rails.env.test? ? 1 : 12
+  # == Password hashing
+  config.stretches               = Rails.env.test? ? 1 : 12
 
-  # Confirmable
-  config.reconfirmable = true
+  # == Confirmable
+  config.reconfirmable           = true
 
-  # Rememberable
+  # == Rememberable
   config.expire_all_remember_me_on_sign_out = true
 
-  # Validatable
-  config.password_length = 6..128
-  config.email_regexp    = /\A[^@\s]+@[^@\s]+\z/
+  # == Validatable
+  config.password_length         = 6..128
+  config.email_regexp            = /\A[^@\s]+@[^@\s]+\z/
 
-  # Recoverable
-  config.reset_password_within = 6.hours
+  # == Recoverable
+  config.reset_password_within   = 6.hours
 
-  # Scoped views
-  config.scoped_views = true
+  # == Scoped views（users/* ビューを使う）
+  config.scoped_views            = true
 
-  # Sign out
-  config.sign_out_via = :delete
+  # == Sign out
+  config.sign_out_via            = :delete
 
-  # Hotwire / Turbo
+  # == Hotwire / Turbo
   config.responder.error_status    = :unprocessable_entity
   config.responder.redirect_status = :see_other
   config.navigational_formats      = [ "*/*", :html, :turbo_stream ]
 
-  # ===================== OmniAuth（Google） =====================
-  # GCP 側の「承認済みのリダイレクトURI」に *完全一致* で下記を登録しておくこと
-  # - http://localhost:3000/users/auth/google_oauth2/callback   （開発）
-  # - https://<本番ドメイン>/users/auth/google_oauth2/callback  （本番）
+  # ======================== OmniAuth（Google） ========================
+  # GCPの「承認済みのリダイレクトURI」に *完全一致* で以下を登録しておくこと
+  #   - http://localhost:3000/users/auth/google_oauth2/callback（開発）
+  #   - https://<本番ドメイン>/users/auth/google_oauth2/callback（本番）
   require "omniauth-google-oauth2"
 
   google_id     = ENV["GOOGLE_CLIENT_ID"]
   google_secret = ENV["GOOGLE_CLIENT_SECRET"]
 
-  config.omniauth :google_oauth2,
-                  google_id,
-                  google_secret,
-                  {
-                    scope:       "openid,email,profile",
-                    prompt:      "select_account",     # ← Googleの画面でアカウント選択
-                    access_type: "online",
-                    # 重要：redirect_uri は **指定しない**（環境依存のズレを防ぐ）
-                    client_options: {
-                      authorize_url: "https://accounts.google.com/o/oauth2/v2/auth",
-                      token_url:     "https://oauth2.googleapis.com/token"
-                    }
-                  }
-  # =============================================================
+  # setup: ブロックで毎リクエスト最終上書き（prompt=none等の外部上書きを無効化）
+  config.omniauth(
+    :google_oauth2,
+    google_id,
+    google_secret,
+    scope:        "openid email profile",
+    access_type:  "online",
+    prompt:       "select_account",
+    client_options: {
+      authorize_url: "https://accounts.google.com/o/oauth2/v2/auth",
+      token_url:     "https://oauth2.googleapis.com/token"
+    },
+    setup: lambda { |env|
+      s = env["omniauth.strategy"]
+
+      # host 決定（ENV優先 → 逆プロキシヘッダ → rack.url_scheme/HTTP_HOST）
+      app_host =
+        if ENV["APP_HOST"].present?
+          ENV["APP_HOST"]
+        else
+          scheme = env["HTTP_X_FORWARDED_PROTO"] || env["rack.url_scheme"] || "https"
+          host   = env["HTTP_X_FORWARDED_HOST"]  || env["HTTP_HOST"]
+          "#{scheme}://#{host}"
+        end
+
+      # 認証時に毎回“正しい”値を強制
+      s.options[:scope]        = "openid email profile"
+      s.options[:prompt]       = "select_account"
+      s.options[:redirect_uri] = "#{app_host}/users/auth/google_oauth2/callback"
+    }
+  )
+  # ===================================================================
 end
 
-# ===== OmniAuth のホスト判定（逆プロキシ対策 & 本番固定オプション）=====
+# ===== OmniAuth の共通設定（逆プロキシ配下のホスト判断を安定させる） =====
 require "omniauth"
 
-# APP_HOST があればそれを最優先で利用（例: https://fasty-web.onrender.com）
 OmniAuth.config.full_host = lambda do |env|
   if ENV["APP_HOST"].present?
     ENV["APP_HOST"]
@@ -80,9 +97,9 @@ OmniAuth.config.full_host = lambda do |env|
   end
 end
 
-# OmniAuth v2 で GET を許容（直リンクや戻る等での失敗を避ける）
+# OmniAuth v2: GET も許容（リンク直叩き対策）
 OmniAuth.config.allowed_request_methods = %i[post get]
 OmniAuth.config.silence_get_warning     = true
 
-# ロガー
+# ログは Rails.logger へ
 OmniAuth.config.logger = Rails.logger


### PR DESCRIPTION
## 目的
本番で発生していた `invalid_grant: Bad Request` を解消し、Googleログインの成功率を安定化する。

## 変更点
- Devise/OmniAuth の Google 設定に `setup` を追加
  - 毎リクエストで `prompt: "select_account"` を強制
  - `redirect_uri` を APP_HOST（または実リクエストHost）から生成して固定
- 逆プロキシ配下でのホスト判定を安定化（full_hostの補強）

## 確認手順
1. デプロイ後、ブラウザで DevTools → Application → Clear storage → **Clear site data**
2. 「Googleでログイン」実行
3. Render Logs の Parameters に `prompt=>"select_account"` が出ていること
4. `/users/auth/google_oauth2/callback` に戻って正常サインインできること

## 事前条件（再掲）
- GCP OAuth クライアントのリダイレクトURI：
  - `https://fasty-web.onrender.com/users/auth/google_oauth2/callback`
- Render 環境変数：
  - `APP_HOST=https://fasty-web.onrender.com`
  - `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`
  - `RAILS_SERVE_STATIC_FILES=1`
