### PR TITLE
Googleログイン安定化: authorize_paramsでprompt/redirect_uri/scopeを強制（invalid_grant対策）

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -30,7 +30,7 @@ Devise.setup do |config|
   # == Recoverable
   config.reset_password_within   = 6.hours
 
-  # == Scoped views（users/* ビューを使う）
+  # == Scoped views
   config.scoped_views            = true
 
   # == Sign out
@@ -42,30 +42,28 @@ Devise.setup do |config|
   config.navigational_formats      = [ "*/*", :html, :turbo_stream ]
 
   # ======================== OmniAuth（Google） ========================
-  # GCPの「承認済みのリダイレクトURI」に *完全一致* で以下を登録しておくこと
-  #   - http://localhost:3000/users/auth/google_oauth2/callback（開発）
-  #   - https://<本番ドメイン>/users/auth/google_oauth2/callback（本番）
+  # GCP の「承認済みのリダイレクトURI」は完全一致で登録：
+  # - http://localhost:3000/users/auth/google_oauth2/callback
+  # - https://<本番ドメイン>/users/auth/google_oauth2/callback
   require "omniauth-google-oauth2"
 
   google_id     = ENV["GOOGLE_CLIENT_ID"]
   google_secret = ENV["GOOGLE_CLIENT_SECRET"]
 
-  # setup: ブロックで毎リクエスト最終上書き（prompt=none等の外部上書きを無効化）
   config.omniauth(
     :google_oauth2,
     google_id,
     google_secret,
     scope:        "openid email profile",
-    access_type:  "online",
-    prompt:       "select_account",
+    access_type:  "offline",
     client_options: {
       authorize_url: "https://accounts.google.com/o/oauth2/v2/auth",
       token_url:     "https://oauth2.googleapis.com/token"
     },
+    # ★毎リクエストで最終上書き（prompt=none を無効化・redirect_uri を固定）
     setup: lambda { |env|
       s = env["omniauth.strategy"]
 
-      # host 決定（ENV優先 → 逆プロキシヘッダ → rack.url_scheme/HTTP_HOST）
       app_host =
         if ENV["APP_HOST"].present?
           ENV["APP_HOST"]
@@ -75,16 +73,27 @@ Devise.setup do |config|
           "#{scheme}://#{host}"
         end
 
-      # 認証時に毎回“正しい”値を強制
+      redirect_uri = "#{app_host}/users/auth/google_oauth2/callback"
+
+      # options にも、実際にURLへ載る authorize_params にも両方セット
+      s.options[:redirect_uri] = redirect_uri
       s.options[:scope]        = "openid email profile"
-      s.options[:prompt]       = "select_account"
-      s.options[:redirect_uri] = "#{app_host}/users/auth/google_oauth2/callback"
+      s.options[:access_type]  = "offline"
+
+      s.options.authorize_params["prompt"]       = "select_account"
+      s.options.authorize_params["redirect_uri"] = redirect_uri
+      s.options.authorize_params["scope"]        = "openid email profile"
+      s.options.authorize_params["access_type"]  = "offline"
+
+      # 外部から混入した prompt を破棄（保険）
+      env["rack.request.query_hash"]&.delete("prompt")
+      env["rack.request.form_hash"]&.delete("prompt")
     }
   )
   # ===================================================================
 end
 
-# ===== OmniAuth の共通設定（逆プロキシ配下のホスト判断を安定させる） =====
+# ===== OmniAuth 共通設定（逆プロキシ下のホスト解決を安定化） =====
 require "omniauth"
 
 OmniAuth.config.full_host = lambda do |env|
@@ -97,9 +106,9 @@ OmniAuth.config.full_host = lambda do |env|
   end
 end
 
-# OmniAuth v2: GET も許容（リンク直叩き対策）
+# OmniAuth v2: GET も許容（直リンク対策）
 OmniAuth.config.allowed_request_methods = %i[post get]
 OmniAuth.config.silence_get_warning     = true
 
-# ログは Rails.logger へ
+# ログ
 OmniAuth.config.logger = Rails.logger


### PR DESCRIPTION
## 概要

prompt=none 混入をサーバ側で無効化し select_account を強制

redirect_uri を毎リクエストで確定（APP_HOST優先）

逆プロキシ配下でも安定

確認手順

マージ後、Renderで「Clear build cache & Deploy」

ブラウザ：DevTools → Application → Clear storage → Clear site data → ハードリロード

「Googleでログイン」実行

Renderログの Parameters に
prompt=>"select_account" と
redirect_uri=>"https://fasty-web.onrender.com/users/auth/google_oauth2/callback"
が出ていればOK