### PR TITLE
Googleログイン修正: redirect_uriの動的化＋prompt整理＋環境変数確認ログ追加

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -23,11 +23,11 @@ Devise.setup do |config|
   require "devise/orm/active_record"
 
   # == Authentication keys
-  config.case_insensitive_keys   = [:email]
-  config.strip_whitespace_keys   = [:email]
+  config.case_insensitive_keys   = [ :email ]
+  config.strip_whitespace_keys   = [ :email ]
 
   # == Session / Security
-  config.skip_session_storage    = [:http_auth]
+  config.skip_session_storage    = [ :http_auth ]
 
   # == Password hashing
   config.stretches               = Rails.env.test? ? 1 : 12
@@ -54,7 +54,7 @@ Devise.setup do |config|
   # == Hotwire / Turbo
   config.responder.error_status    = :unprocessable_entity
   config.responder.redirect_status = :see_other
-  config.navigational_formats      = ["*/*", :html, :turbo_stream]
+  config.navigational_formats      = [ "*/*", :html, :turbo_stream ]
 
   # ======================== OmniAuth（Google） ========================
   # GCP: 承認済みのリダイレクトURIは完全一致で登録しておくこと

--- a/config/initializers/oauth_env_probe.rb
+++ b/config/initializers/oauth_env_probe.rb
@@ -1,5 +1,5 @@
 # 起動時に一度だけENVの値をマスクしてログ出力
-mask = ->(s){ s.present? ? "#{s[0,4]}...#{s[-4,4]}" : "(nil)" }
+mask = ->(s) { s.present? ? "#{s[0, 4]}...#{s[-4, 4]}" : "(nil)" }
 
 Rails.logger.info(
   "[OAuth Probe] GOOGLE_CLIENT_ID=#{mask.(ENV['GOOGLE_CLIENT_ID'])} " \


### PR DESCRIPTION
## 概要
Google OAuth2 ログインで発生していた `invalid_grant` エラー（Bad Request）を解消。

## 対応内容
- `redirect_uri` を環境に応じて動的に設定（localhost / Render 双方対応）
- `prompt=none` を排除し、`prompt=select_account consent` に変更
- OmniAuth full_host の逆プロキシ対応を追加
- 起動時に ENV 値をマスク出力する probe 初期化子を追加（デバッグ用）

## 確認項目
- GCP の「承認済みのリダイレクトURI」が以下2つになっていること
  - http://localhost:3000/users/auth/google_oauth2/callback
  - https://fasty-web.onrender.com/users/auth/google_oauth2/callback
- Render 環境変数 `GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET` の末尾4桁が GCP の設定と一致
- ローカル／本番ともに Google ログインが成功すること

## 備考
- probe 確認後、`config/initializers/oauth_env_probe.rb` は削除予定
