### PR TITLE
Googleログイン安定化: redirect_uri動的設定・POST限定・二重到達ガード・ビュー修正

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,29 +1,37 @@
 # frozen_string_literal: true
 
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # /users/auth/google_oauth2/callback
   def google_oauth2
     state = params[:state].to_s
     code  = params[:code].to_s
-    state_key = "oauth:google:state:#{state}:ok"
-    code_key  = "oauth:google:code:#{code}:ok"
+
+    state_key = state.present? ? "oauth:google:state:#{state}:ok" : nil
+    code_key  = code.present?  ? "oauth:google:code:#{code}:ok"   : nil
 
     # すでにOK印がある＝重複到達。ユーザーIDが取れれば sign_in して通す
-    if (uid = (Rails.cache.read(state_key) || Rails.cache.read(code_key)))
-      Rails.logger.info("[OmniAuth] duplicate callback (cache hit), signin user_id=#{uid}")
+    if (uid = read_dup_uid(state_key, code_key))
+      Rails.logger.info("[OmniAuth] duplicate callback; signin user_id=#{uid} state_tail=#{state.last(6)}")
       user = User.find_by(id: uid)
       sign_in(user) if user && !user_signed_in?
       return redirect_to(after_sign_in_path_for(current_user || user || :user))
     end
 
     auth = request.env["omniauth.auth"]
-    if auth&.info&.email.blank?
-      Rails.logger.error("[OmniAuth] email missing in auth.info")
+    unless auth
+      Rails.logger.error("[OmniAuth] auth hash is nil (state_tail=#{state.last(6)})")
+      set_flash_message!(:alert, :failure, kind: "Google", reason: "認証情報を取得できませんでした")
+      return redirect_to new_user_session_path
+    end
+
+    if auth.info&.email.blank?
+      Rails.logger.error("[OmniAuth] email missing in auth.info (state_tail=#{state.last(6)})")
       set_flash_message!(:alert, :failure, kind: "Google", reason: "メールアドレスの取得に失敗しました")
       return redirect_to new_user_session_path
     end
 
     begin
-      @user = User.from_google(auth)
+      @user = User.from_google(auth) # ※ User.from_google は既存の実装を利用
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.error("[OmniAuth] save failed: #{e.record.errors.full_messages.join(', ')}")
       set_flash_message!(:alert, :failure, kind: "Google", reason: "ユーザーを作成・更新できませんでした")
@@ -36,8 +44,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     if @user.persisted?
       # 成功印として user_id を保存（2分で失効）
-      Rails.cache.write(state_key, @user.id, expires_in: 2.minutes)
-      Rails.cache.write(code_key,  @user.id, expires_in: 2.minutes)
+      write_dup_uid(state_key, @user.id)
+      write_dup_uid(code_key,  @user.id)
 
       set_flash_message!(:notice, :success, kind: "Google")
       sign_in_and_redirect @user, event: :authentication
@@ -49,16 +57,17 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     end
   end
 
+  # /users/auth/failure
   def failure
     state = params[:state].to_s
     code  = params[:code].to_s
-    state_key = "oauth:google:state:#{state}:ok"
-    code_key  = "oauth:google:code:#{code}:ok"
+    state_key = state.present? ? "oauth:google:state:#{state}:ok" : nil
+    code_key  = code.present?  ? "oauth:google:code:#{code}:ok"   : nil
 
     # 1回目成功済みなら user_id を取り出して sign_in して通す
-    if user_signed_in? || (uid = (Rails.cache.read(state_key) || Rails.cache.read(code_key)))
+    if user_signed_in? || (uid = read_dup_uid(state_key, code_key))
       user = current_user || User.find_by(id: uid)
-      Rails.logger.info("[OmniAuth][failure] treated as success; sign_in user_id=#{user&.id}")
+      Rails.logger.info("[OmniAuth][failure->success] dup ignored; user_id=#{user&.id} state_tail=#{state.last(6)}")
       sign_in(user) if user && !user_signed_in?
       return redirect_to(after_sign_in_path_for(user || current_user || :user))
     end
@@ -75,6 +84,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         reason=#{reason.inspect}
         error_class=#{err&.class}
         error_message=#{err&.message}
+        state_tail=#{state.last(6)}
     LOG
 
     msg = reason.presence || (type && type.to_s.humanize) || "Googleログインがキャンセルされました。"
@@ -90,5 +100,18 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def after_omniauth_failure_path_for(_scope)
     new_user_session_path
+  end
+
+  private
+
+  # 重複検出: state/code のどちらかでヒットした user_id を返す
+  def read_dup_uid(state_key, code_key)
+    Rails.cache.read(state_key) || Rails.cache.read(code_key)
+  end
+
+  # 成功印の保存（key が nil/blank のときは何もしない）
+  def write_dup_uid(key, uid)
+    return if key.blank?
+    Rails.cache.write(key, uid, expires_in: 2.minutes)
   end
 end

--- a/app/views/shared/_google_sign_in.html.erb
+++ b/app/views/shared/_google_sign_in.html.erb
@@ -1,8 +1,8 @@
-<%# Google OAuth ボタン（Turbo 介入を避けるため turbo=false） %>
 <%= button_to user_google_oauth2_omniauth_authorize_path,
               method: :post,
               form: { class: "inline", data: { turbo: false } },
-              class: "btn-google" do %>
+              class: "btn-google",
+              aria: { label: "Googleでログイン" } do %>
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" class="g-icon" aria-hidden="true">
     <path fill="#FFC107" d="M43.611 20.083h-1.611V20H24v8h11.303C33.994 31.91 29.49 35 24 35c-6.627 0-12-5.373-12-12s5.373-12 12-12c3.059 0 5.844 1.164 7.949 3.061l5.657-5.657C34.869 5.053 29.706 3 24 3 12.955 3 4 11.955 4 23s8.955 20 20 20 20-8.955 20-20c0-1.342-.138-2.651-.389-3.917z"/>
     <path fill="#FF3D00" d="M6.306 14.691l6.571 4.817C14.422 16.75 18.873 14 24 14c3.059 0 5.844 1.164 7.949 3.061l5.657-5.657C34.869 5.053 29.706 3 24 3 16.316 3 9.611 7.337 6.306 14.691z"/>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -8,10 +8,12 @@
     <div class="devise-card">
       <%= render "users/shared/error_messages", resource: resource %>
 
-      <%= form_for(resource,
-                   as: resource_name,
-                   url: session_path(resource_name),
-                   html: { data: { turbo: false }, role: "form", "aria-labelledby": "login-form-title" }) do |f| %>
+      <%= form_for(
+            resource,
+            as: resource_name,
+            url: session_path(resource_name),
+            html: { data: { turbo: false }, role: "form", "aria-labelledby": "login-form-title" }
+          ) do |f| %>
         <span id="login-form-title" class="sr-only"><%= t('devise.sessions.new.sign_in') %></span>
 
         <div class="devise-field">
@@ -51,9 +53,10 @@
         <%= button_to user_google_oauth2_omniauth_authorize_path,
                       method: :post,
                       form: { class: "inline", data: { turbo: false } },
-                      class: "oauth-btn oauth-btn--google oauth-btn--borderless" do %>
-          <span class="oauth-btn__icon" aria-hidden="true"></span>
-            <svg width="18" height="18" viewBox="0 0 48 48" aria-hidden="true">
+                      class: "oauth-btn oauth-btn--google oauth-btn--borderless",
+                      aria: { label: "Googleでログイン" } do %>
+          <span class="oauth-btn__icon" aria-hidden="true">
+            <svg width="18" height="18" viewBox="0 0 48 48">
               <path fill="#FFC107" d="M43.6 20.5H42V20H24v8h11.3C34 32.9 29.5 36 24 36 16.8 36 11 30.2 11 23s5.8-13 13-13c3.1 0 5.9 1.1 8.1 2.9l5.7-5.7C34.2 4.9 29.4 3 24 3 12.3 3 3 12.3 3 24s9.3 21 21 21c10.8 0 20-7.8 20-21 0-1.3-.1-2.2-.4-3.5z"/>
               <path fill="#FF3D00" d="M6.3 14.7l6.6 4.8C14.5 16 18.9 13 24 13c3.1 0 5.9 1.1 8.1 2.9l5.7-5.7C34.2 4.9 29.4 3 24 3 16 3 9.2 7.6 6.3 14.7z"/>
               <path fill="#4CAF50" d="M24 45c5.4 0 10.2-1.8 13.6-4.9l-6.3-5.2C29.5 36 26.9 37 24 37c-5.4 0-9.9-3.6-11.4-8.5l-6.5 5C8.9 41.8 15.9 45 24 45z"/>


### PR DESCRIPTION
背景

本番/ローカルで invalid_grant が散発。redirect_uri の不一致やGET誤発火、二重到達で失敗するケースがあり、安定化を行いました。

主な変更

devise.rb:

OmniAuth.config.full_host をリバプロ対応で解決

開始エンドポイントを POST限定 に（allowed_request_methods = %i[post]）

setup で redirect_uri を request.base_url から動的に完全一致設定

authorize_params に scope/prompt/access_type を明示

Users::OmniauthCallbacksController:

state/code ベースの 二重到達ガード（Rails.cache, 2分） を追加

失敗時も「1回目成功済み」は通す処理を整備

ログの整備（原因追跡しやすく）

ビュー（_google_sign_in.html.erb, users/sessions/new.html.erb）:

button_to + method: :post 固定、Turbo無効化、アクセシビリティ微調整

動作確認（ローカル）

.env.development に GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET を設定

Google Cloud の “Authorized redirect URIs” に
http://localhost:3000/users/auth/google_oauth2/callback を 完全一致 で登録

シークレットウィンドウで Googleログイン → /mypage へ遷移

連続クリック/戻る→進む でも重複ログインエラーが発生しないこと

本番の注意

APP_HOST=https://fasty-web.onrender.com をRender環境に設定

GCPのリダイレクトURIに
https://fasty-web.onrender.com/users/auth/google_oauth2/callback を登録