### PR TITLE
fix: メニュードロワーから「健康と安全」を削除

### DIFF
--- a/app/views/shared/_menu_drawer.html.erb
+++ b/app/views/shared/_menu_drawer.html.erb
@@ -24,13 +24,6 @@
       </li>
 
       <li>
-        <%= link_to health_notice_path,
-              class: "inline-flex items-center px-3 py-2 rounded hover:bg-white/10 whitespace-nowrap" do %>
-          健康と安全
-        <% end %>
-      </li>
-
-      <li>
         <%= link_to new_contact_path,
               class: "inline-flex items-center px-3 py-2 rounded hover:bg-white/10 whitespace-nowrap" do %>
           お問い合わせ


### PR DESCRIPTION
初回同意モーダル導入に伴い、常時ナビから『健康と安全』リンクを削除しました。

### 変更点
- app/views/shared/_menu_drawer.html.erb: 対象リンク行を削除

### 影響範囲
- ナビゲーションからの導線のみ。初回同意モーダル/規約本文は変更なし

### スクリーンショット

<img width="369" height="555" alt="スクリーンショット 2025-11-03 19 08 42" src="https://github.com/user-attachments/assets/c2f0be9c-10c7-4e1a-b841-b1bcd86b2b3e" />
