### PR TITLE
Session: SameSite=Lax + secure クッキーでCSRF安定化（HTTPS強制運用向け）

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,4 @@
+Rails.application.config.session_store :cookie_store,
+  key: "_fasty_session",
+  secure: Rails.env.production?, # HTTPSのみ
+  same_site: :lax               # OAuth/Turboと相性◯


### PR DESCRIPTION
## 目的
- ログアウトなど非GETリクエストで稀に発生する CSRF 422 ノイズを削減し、セッションの安定性を高めるため。

## 変更点
- `config/initializers/session_store.rb` を追加し、セッションを以下で統一
  - `cookie_store`
  - `key: "_fasty_session"`
  - `secure: Rails.env.production?`（HTTPS時のみ送信）
  - `same_site: :lax`（OAuth/Turbo と相性が良く実運用向き）

## 補足（確認事項）
- `config/environments/production.rb` に `config.force_ssl = true` を設定済み（✅/要確認）
- ログアウトリンクは `button_to ... , method: :delete` を使用（✅/要確認）

## 動作確認
- 開発環境でログイン→ログアウトが正常に動作すること
- 本番（Render）で、デプロイ直後も含めて `DELETE /users/sign_out` で 422 が発生しない／発生率が下がることを確認予定

## 影響範囲
- セッション管理（DB変更なし）
- 既存のログイン/ログアウトフローのみ

## 関連
- CSRF 422（`InvalidAuthenticityToken`）の発生ログを低減するための安定化対応
