### PR TITLE
カレンダーのモバイル最適化：正方形セル化／本日強調／文言非表示（PC据え置き）

### DIFF
--- a/app/views/fasting_records/calendar.html.erb
+++ b/app/views/fasting_records/calendar.html.erb
@@ -2,10 +2,7 @@
 <% content_for :title, "断食カレンダー" %>
 
 <div class="mx-auto max-w-5xl p-4 pb-28 md:pb-32">
-  <!-- 読みやすさ重視：白80% + 強めのblur + 薄い枠 + 影 -->
   <div class="rounded-3xl bg-white/80 backdrop-blur-xl ring-1 ring-stone-300/60 shadow-xl p-4 sm:p-5">
-
-    <!-- 見出し + 月移動 -->
     <div class="flex items-center justify-between gap-2 flex-wrap">
       <h1 class="text-lg sm:text-xl md:text-2xl font-semibold text-stone-900">
         断食カレンダー
@@ -13,66 +10,59 @@
       </h1>
       <div class="flex items-center gap-2 flex-wrap text-xs sm:text-sm">
         <%= link_to "前月",
-          calendar_fasting_records_path(year: @prev_year, month: @prev_month),
-          class: "px-3 py-1.5 rounded-xl ring-1 ring-stone-300 bg-white/70 hover:bg-white/90" %>
+                    calendar_fasting_records_path(year: @prev_year, month: @prev_month),
+                    class: "px-3 py-1.5 rounded-xl ring-1 ring-stone-300 bg-white/70 hover:bg-white/90" %>
         <%= link_to "今月",
-          calendar_fasting_records_path(year: @today.year, month: @today.month),
-          class: "px-3 py-1.5 rounded-xl ring-1 ring-sky-200 bg-white/70 hover:bg-white/90" %>
+                    calendar_fasting_records_path(year: @today.year, month: @today.month),
+                    class: "px-3 py-1.5 rounded-xl ring-1 ring-sky-200 bg-white/70 hover:bg-white/90" %>
         <%= link_to "翌月",
-          calendar_fasting_records_path(year: @next_year, month: @next_month),
-          class: "px-3 py-1.5 rounded-xl ring-1 ring-stone-300 bg-white/70 hover:bg-white/90" %>
+                    calendar_fasting_records_path(year: @next_year, month: @next_month),
+                    class: "px-3 py-1.5 rounded-xl ring-1 ring-stone-300 bg-white/70 hover:bg-white/90" %>
       </div>
     </div>
 
-    <!-- 曜日ヘッダ -->
     <div class="mt-4 grid grid-cols-7 gap-2 text-[10px] sm:text-[12px] md:text-sm">
       <% %w[月 火 水 木 金 土 日].each do |w| %>
         <div class="px-2 py-1 text-center font-medium text-stone-700"><%= w %></div>
       <% end %>
     </div>
 
-    <!-- カレンダー本体 -->
     <div class="mt-1 grid grid-cols-7 gap-2">
       <% day = @calendar_start %>
       <% while day <= @calendar_end %>
         <% record = @records_by_date[day] %>
-        <%= link_to fasting_records_path(date: day),
-          class: day_cell_classes(day, @month),
-          "aria-label": "#{day.strftime('%Y/%m/%d')} の記録一覧へ" do %>
 
-          <!-- 日付 + 本日バッジ -->
-          <div class="flex items-center justify-between">
-            <div class="text-sm font-medium <%= day == @today ? 'text-sky-700' : 'text-stone-900' %>">
-              <%= day.day %>
+        <%= link_to fasting_records_path(date: day),
+                    class: day_cell_outer_classes(day),
+                    "aria-label": "#{day.strftime('%Y/%m/%d')} の記録一覧へ" do %>
+
+          <div class="<%= day_cell_classes(day, @month) %>">
+            <div class="flex items-start justify-between">
+              <%# 本日: モバイルは色だけ、PCはバッジも表示 %>
+              <div class="text-sm font-medium <%= day == @today ? 'text-sky-700' : 'text-stone-900' %>">
+                <%= day.day %>
+              </div>
+              <% if day == @today %>
+                <span class="hidden sm:inline-flex text-[10px] px-2 py-0.5 rounded bg-sky-100 text-sky-700 ring-1 ring-sky-200">
+                  <%= t("calendar.today") %>
+                </span>
+              <% end %>
             </div>
-            <% if day == @today %>
-              <span class="text-[10px] px-2 py-0.5 rounded bg-sky-100 text-sky-700 ring-1 ring-sky-200">
-                <%= t("calendar.today") %>
-              </span>
+
+            <% if record %>
+              <%# 状態バッジのみ表示（時間等は出さない） %>
+              <div class="mt-1"><%= fasting_badge_for(record) %></div>
+            <% else %>
+              <%# モバイルは文言非表示、>=sm だけ “記録なし” を出す %>
+              <div class="mt-2 text-[11px] text-stone-500 hidden sm:block">記録なし</div>
             <% end %>
           </div>
 
-          <!-- 記録の要約 -->
-          <% if record %>
-            <div class="mt-1"><%= fasting_badge_for(record) %></div>
-            <div class="mt-1 text-[11px] text-stone-700 leading-tight">
-              <% if record.end_time.present? %>
-                <%= (record.target_hours || "-") %>h
-                <%= record.start_time.strftime("%H:%M") %>→<%= record.end_time.strftime("%H:%M") %>
-              <% else %>
-                <%= (record.target_hours || "-") %>h
-                <%= record.start_time.strftime("%H:%M") %>〜
-              <% end %>
-            </div>
-          <% else %>
-            <div class="mt-2 text-[11px] text-stone-500">記録なし</div>
-          <% end %>
         <% end %>
         <% day += 1.day %>
       <% end %>
     </div>
 
-    <!-- 凡例 -->
     <div class="mt-6 flex flex-wrap items-center gap-3 text-[12px] text-stone-800">
       <span class="inline-flex items-center gap-1">
         <span class="inline-block w-5"><%= tailwind_badge("◯", "bg-green-100 text-green-700 ring-green-200") %></span> 成功


### PR DESCRIPTION
## 変更概要
- モバイルで日付セルを正方形に統一
- モバイルでは「本日」「記録なし」の文言を非表示（視認性向上）
- 本日セルのみ色で明確に強調
- PCの見た目は据え置き（既存レイアウトを維持）
- 記録があっても月カレンダーでは所要時間等は非表示（クリックで当日詳細へ）

## 関連Issue
Refs #164

## 動作確認
- iPhone実機/DevToolsでのレスポンシブ確認
- クリックで当日一覧に遷移
- RuboCop: OK
