### PR TITLE
モバイルUI: 日付数字の色チップ化（カレンダー可読性向上）

### DIFF
--- a/app/helpers/fasting_records_helper.rb
+++ b/app/helpers/fasting_records_helper.rb
@@ -18,7 +18,7 @@ module FastingRecordsHelper
     t.strftime("%Y/%m/%d(#{WDAY_JA[t.wday]})")
   end
 
-  # === 絞り込みUI用 ===
+  # === 絞り込みUI用
   def status_filter_options
     [
       [ "すべて",      "" ],
@@ -31,88 +31,15 @@ module FastingRecordsHelper
   # 旧パラメータ(success/failure)との互換
   def normalized_status_param(raw)
     case raw.to_s
-    when "success"   then "achieved"
-    when "failure"   then "unachieved"
+    when "success" then "achieved"
+    when "failure" then "unachieved"
     else raw
     end
   end
 
-  # バッジ（達成/未達成/進行中）
-  def status_badge(record)
-    key =
-      if record.respond_to?(:status_key)
-        record.status_key
-      elsif record.respond_to?(:status)
-        (record.status rescue nil)&.to_sym
-      end
-
-    case key
-    when :achieved
-      content_tag(:span, "達成",   class: "badge badge--ok")
-    when :unachieved
-      content_tag(:span, "未達成", class: "badge badge--ng")
-    else
-      content_tag(:span, "進行中", class: "badge badge--info")
-    end
-  end
-
-  # コメント抜粋（任意）
-  def comment_snippet(record, length: 60)
-    text = record.respond_to?(:comment_text) ? record.comment_text.to_s.strip : ""
-    return "".html_safe if text.blank?
-
-    content_tag(:div, class: "record-comment", title: text) do
-      safe_join([
-        content_tag(:span, "💬", aria: { hidden: true }),
-        content_tag(:span, " "),
-        content_tag(:span, truncate(text, length: length))
-      ])
-    end
-  end
-
-  def snippet_plain_text(record, length: 60)
-    text = record.respond_to?(:comment_text) ? record.comment_text.to_s.strip : ""
-    truncate(text, length: length)
-  end
-
-  # ===== カレンダー用 =====
-
-  # モバイルだけ「正方形」にするための外側ラッパー（aタグ）用クラス
-  # - mobile: pb-[100%] で正方形ボックス化（position: relative 前提）
-  # - >=sm: 通常フロー
-  def day_cell_outer_classes(_day)
-    "relative block pb-[100%] sm:pb-0"
-  end
-
-  # 内側（実表示）用クラス
-  # - >=sm では従来通りの高さを確保
-  # - ホバー/フォーカスの視認性、今日の薄いリング
-  def day_cell_classes(day, target_month)
-    is_today = (day == Time.zone.today)
-
-    base = [
-      # 内側はモバイルで absolute 展開して正方形にフィット
-      "absolute inset-0",
-      "rounded-xl flex flex-col gap-2 p-2 cursor-pointer",
-      # ベース
-      "bg-white ring-1 ring-stone-200 shadow-sm",
-      # 変化
-      "transition-colors transition-transform duration-150",
-      "hover:bg-sky-50 hover:ring-sky-300 hover:shadow-md hover:shadow-sky-100/60",
-      "focus-visible:outline-none focus-visible:bg-sky-50",
-      "focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:shadow-lg",
-      "active:bg-sky-100 active:shadow",
-      "hover:-translate-y-[1px] active:scale-[0.99] motion-reduce:transform-none",
-      # デスクトップでは最低高を確保
-      "sm:static sm:min-h-[96px]"
-    ]
-    base << "ring-sky-200" if is_today
-
-    klass = base.join(" ")
-    day.month == target_month ? "#{klass} text-stone-800" : "#{klass} text-stone-400"
-  end
-
+  # ========== バッジ（PC用） ==========
   # 状態 → 記号・色（Tailwind semantic）
+  # success=green / ongoing=amber / fail=rose
   def fasting_badge_for(record)
     return if record.nil?
 
@@ -125,12 +52,64 @@ module FastingRecordsHelper
     end
   end
 
-  # 汎用バッジ
+  # 汎用：Tailwindバッジ
   def tailwind_badge(text, color_classes)
     content_tag(:span, text,
       class: "inline-flex items-center justify-center text-[12px] px-2 py-0.5 rounded-lg ring-1 #{color_classes}")
   end
   alias badge tailwind_badge
+
+  # ========== モバイル用：日付数字の“丸チップ”を色分け ==========
+  # recordの状態に応じて日付数字をカラーリング（sm未満のみ表示）
+  # - 成功: 緑 / 途中: 黄 / 未達: 赤 / 記録なし: デフォルト
+  def mobile_colored_day_number(day, record, today:)
+    base = "inline-flex sm:hidden items-center justify-center w-7 h-7 rounded-full text-[13px] font-medium"
+    classes =
+      if record.present?
+        if record.success == true
+          "bg-green-500/90 text-white"
+        elsif record.end_time.nil?
+          "bg-amber-500/90 text-white"
+        else
+          "bg-rose-500/90 text-white"
+        end
+      else
+        "bg-transparent text-stone-900"
+      end
+
+    # 今日の強調（枠線）※色は状態そのまま、枠だけ淡いスカイ
+    classes += " ring-2 ring-sky-300" if today
+
+    content_tag(:span, day.day, class: "#{base} #{classes}")
+  end
+
+  # PC用の日付（sm以上で表示）
+  def desktop_day_number(day, today:)
+    color = today ? "text-sky-700" : "text-stone-900"
+    content_tag(:span, day.day, class: "hidden sm:inline text-sm font-medium #{color}")
+  end
+
+  # 日セル（共通）
+  # 当月外は“文字色だけ”薄く（opacityは使わない）
+  def day_cell_classes(day, target_month)
+    is_today = (day == Time.zone.today)
+    base = [
+      # モバイルは正方形を意識して高さ控えめ / sm以降はゆとり
+      "min-h-[58px] sm:min-h-[76px] md:min-h-[96px]",
+      "p-2 rounded-xl flex flex-col gap-2 cursor-pointer",
+      "bg-white ring-1 ring-stone-200 shadow-sm",
+      "transition-colors transition-transform duration-150",
+      "hover:bg-sky-50 hover:ring-sky-300 hover:shadow-md hover:shadow-sky-100/60",
+      "focus-visible:outline-none focus-visible:bg-sky-50",
+      "focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:shadow-lg",
+      "active:bg-sky-100 active:shadow",
+      "hover:-translate-y-[1px] active:scale-[0.99] motion-reduce:transform-none"
+    ]
+    base << "ring-sky-200" if is_today
+
+    klass = base.join(" ")
+    day.month == target_month ? "#{klass} text-stone-800" : "#{klass} text-stone-400"
+  end
 
   private
 

--- a/app/views/fasting_records/calendar.html.erb
+++ b/app/views/fasting_records/calendar.html.erb
@@ -31,33 +31,33 @@
       <% day = @calendar_start %>
       <% while day <= @calendar_end %>
         <% record = @records_by_date[day] %>
-
         <%= link_to fasting_records_path(date: day),
-                    class: day_cell_outer_classes(day),
+                    class: day_cell_classes(day, @month),
                     "aria-label": "#{day.strftime('%Y/%m/%d')} の記録一覧へ" do %>
 
-          <div class="<%= day_cell_classes(day, @month) %>">
-            <div class="flex items-start justify-between">
-              <%# 本日: モバイルは色だけ、PCはバッジも表示 %>
-              <div class="text-sm font-medium <%= day == @today ? 'text-sky-700' : 'text-stone-900' %>">
-                <%= day.day %>
-              </div>
-              <% if day == @today %>
-                <span class="hidden sm:inline-flex text-[10px] px-2 py-0.5 rounded bg-sky-100 text-sky-700 ring-1 ring-sky-200">
-                  <%= t("calendar.today") %>
-                </span>
-              <% end %>
+          <%# 日付部分：モバイル=色付き丸チップ / デスクトップ=従来表示 %>
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-1">
+              <%= mobile_colored_day_number(day, record, today: (day == @today)) %>
+              <%= desktop_day_number(day, today: (day == @today)) %>
             </div>
 
-            <% if record %>
-              <%# 状態バッジのみ表示（時間等は出さない） %>
-              <div class="mt-1"><%= fasting_badge_for(record) %></div>
-            <% else %>
-              <%# モバイルは文言非表示、>=sm だけ “記録なし” を出す %>
-              <div class="mt-2 text-[11px] text-stone-500 hidden sm:block">記録なし</div>
+            <%# 「本日」ラベルはsm以上のみ %>
+            <% if day == @today %>
+              <span class="hidden sm:inline text-[10px] px-2 py-0.5 rounded bg-sky-100 text-sky-700 ring-1 ring-sky-200">
+                <%= t("calendar.today", default: "本日") %>
+              </span>
             <% end %>
           </div>
 
+          <%# 状態テキストや結果はモバイルでは非表示、PCのみバッジ表示。結果時刻は常に出さない %>
+          <div class="mt-1 hidden sm:block">
+            <% if record %>
+              <%= fasting_badge_for(record) %>
+            <% else %>
+              <div class="text-[11px] text-stone-500">記録なし</div>
+            <% end %>
+          </div>
         <% end %>
         <% day += 1.day %>
       <% end %>


### PR DESCRIPTION
## 概要
- モバイルのみ、セル内バッジを撤去し**日付数字の丸チップ色**で状態を表示（成功=緑/途中=黄/未達=赤）
- 本日のセルは**淡いスカイの枠線**で強調
- モバイルでは「本日」「記録なし」テキストを非表示（情報量圧縮）
- PCでは従来どおり**バッジ＋記録なし**を表示
- いずれの表示でも、結果の\"18h 02:05〜\"等は**非表示**（詳細は日付タップで遷移）

### 目的
- スマホでの視認性・タップ精度・可読性を改善

### 関連
Refs #164