### PR TITLE
カレンダー: モバイルは日付数字の色のみで状態表示（PCは従来バッジ維持）

### DIFF
--- a/app/helpers/fasting_records_helper.rb
+++ b/app/helpers/fasting_records_helper.rb
@@ -112,7 +112,30 @@ module FastingRecordsHelper
     day.month == target_month ? "#{klass} text-stone-800" : "#{klass} text-stone-400"
   end
 
-  # 状態 → 記号・色（Tailwind semantic）
+  # モバイル専用：日付数字に色チップ（丸）を付けるためのクラス
+  # - 成功=緑 / 途中=黄 / 未達=赤 / 本日=淡いスカイ
+  # - sm 以上ではプレーン数字へ視覚的リセット
+  def day_number_chip_classes(record, day, today)
+    base = "inline-flex items-center justify-center w-8 h-8 rounded-full text-[14px] font-semibold ring-1"
+    color =
+      if day == today
+        "bg-sky-50 text-sky-700 ring-sky-200"
+      elsif record.nil?
+        "bg-white text-stone-900 ring-stone-200"
+      elsif record.success == true
+        "bg-green-100 text-green-700 ring-green-200"
+      elsif record.end_time.nil?
+        "bg-amber-100 text-amber-700 ring-amber-200"
+      else
+        "bg-rose-100 text-rose-700 ring-rose-200"
+      end
+
+    responsive_reset = "sm:bg-transparent sm:text-inherit sm:ring-0 sm:w-auto sm:h-auto sm:rounded-none sm:font-medium"
+
+    "#{base} #{color} #{responsive_reset}"
+  end
+
+  # 旧来の◯/△/×バッジ（PC用の凡例で使用可）
   def fasting_badge_for(record)
     return if record.nil?
 

--- a/app/views/fasting_records/calendar.html.erb
+++ b/app/views/fasting_records/calendar.html.erb
@@ -3,6 +3,7 @@
 
 <div class="mx-auto max-w-5xl p-4 pb-28 md:pb-32">
   <div class="rounded-3xl bg-white/80 backdrop-blur-xl ring-1 ring-stone-300/60 shadow-xl p-4 sm:p-5">
+    <!-- 見出し & 月移動 -->
     <div class="flex items-center justify-between gap-2 flex-wrap">
       <h1 class="text-lg sm:text-xl md:text-2xl font-semibold text-stone-900">
         断食カレンダー
@@ -21,12 +22,14 @@
       </div>
     </div>
 
+    <!-- 曜日 -->
     <div class="mt-4 grid grid-cols-7 gap-2 text-[10px] sm:text-[12px] md:text-sm">
       <% %w[月 火 水 木 金 土 日].each do |w| %>
         <div class="px-2 py-1 text-center font-medium text-stone-700"><%= w %></div>
       <% end %>
     </div>
 
+    <!-- カレンダー本体 -->
     <div class="mt-1 grid grid-cols-7 gap-2">
       <% day = @calendar_start %>
       <% while day <= @calendar_end %>
@@ -37,11 +40,9 @@
                     "aria-label": "#{day.strftime('%Y/%m/%d')} の記録一覧へ" do %>
 
           <div class="<%= day_cell_classes(day, @month) %>">
+            <!-- 上段：日付（モバイルは色チップで状態表示） / 本日バッジ(PCのみ) -->
             <div class="flex items-start justify-between">
-              <%# 本日: モバイルは色だけ、PCはバッジも表示 %>
-              <div class="text-sm font-medium <%= day == @today ? 'text-sky-700' : 'text-stone-900' %>">
-                <%= day.day %>
-              </div>
+              <span class="<%= day_number_chip_classes(record, day, @today) %>"><%= day.day %></span>
               <% if day == @today %>
                 <span class="hidden sm:inline-flex text-[10px] px-2 py-0.5 rounded bg-sky-100 text-sky-700 ring-1 ring-sky-200">
                   <%= t("calendar.today") %>
@@ -49,11 +50,10 @@
               <% end %>
             </div>
 
+            <!-- 下段：PCのみバッジ表示 / モバイルは非表示（情報量削減） -->
             <% if record %>
-              <%# 状態バッジのみ表示（時間等は出さない） %>
-              <div class="mt-1"><%= fasting_badge_for(record) %></div>
+              <div class="mt-1 hidden sm:block"><%= fasting_badge_for(record) %></div>
             <% else %>
-              <%# モバイルは文言非表示、>=sm だけ “記録なし” を出す %>
               <div class="mt-2 text-[11px] text-stone-500 hidden sm:block">記録なし</div>
             <% end %>
           </div>
@@ -63,6 +63,7 @@
       <% end %>
     </div>
 
+    <!-- 凡例（PC向け表示想定） -->
     <div class="mt-6 flex flex-wrap items-center gap-3 text-[12px] text-stone-800">
       <span class="inline-flex items-center gap-1">
         <span class="inline-block w-5"><%= tailwind_badge("◯", "bg-green-100 text-green-700 ring-green-200") %></span> 成功


### PR DESCRIPTION
## 目的
モバイルでセル内の◯/△/×バッジが詰まり見づらかったため、日付数字に色のみで状態を表す方式に変更。

## 変更点
- helper: `day_number_chip_classes` を追加し、モバイル時は日付数字に色付与（達成=緑 / 途中=黄 / 未達=赤）
- view: モバイルでは「記録なし」「本日」バッジを非表示、PCでは従来どおり表示
- 時刻などの詳細はカレンダーでは非表示のまま

## 動作確認
- モバイル幅: セルが正方形、日付数字の色のみで状態が分かることを確認
- PC幅: 従来の◯/△/×バッジが表示されることを確認
- 日付クリックで `/fasting_records?date=YYYY-MM-DD` に遷移
