### PR TITLE
Tailwind safelist: カレンダー状態色（bg-*, text-*, ring-*）のパージ回避

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -91,6 +91,9 @@
       <%= render "shared/footer" %>
     </footer>
 
+    <%# Tailwind の safelist（hidden）: 本番ビルドのパージ回避用 %>
+    <%= render "shared/tw_safelist" %>
+
     <!-- Service Worker 登録 -->
     <script>
       if ('serviceWorker' in navigator) {

--- a/app/views/shared/_tw_safelist.html.erb
+++ b/app/views/shared/_tw_safelist.html.erb
@@ -1,0 +1,20 @@
+<%# Tailwind safelist（hidden）: 本番ビルドでパージされないように強制含有 %>
+<div class="hidden">
+  <!-- 背景色（セル用） -->
+  <span class="bg-green-100"></span>
+  <span class="bg-amber-100"></span>
+  <span class="bg-rose-100"></span>
+  <span class="bg-sky-50"></span>
+
+  <!-- 文字色（todayやPC表示で使用） -->
+  <span class="text-green-700"></span>
+  <span class="text-amber-700"></span>
+  <span class="text-rose-700"></span>
+  <span class="text-sky-700"></span>
+
+  <!-- 枠線色（ring-*） -->
+  <span class="ring-1 ring-green-200"></span>
+  <span class="ring-1 ring-amber-200"></span>
+  <span class="ring-1 ring-rose-200"></span>
+  <span class="ring-1 ring-sky-200"></span>
+</div>


### PR DESCRIPTION
## 背景
モバイルのカレンダーで状態別の背景色（成功/途中/未達）が本番でパージされ、全て白になる事象がありました。

## 対応
- shared/_tw_safelist.html.erb を追加（hidden要素に以下を強制含有）
  - 背景: bg-green-50 / bg-amber-50 / bg-rose-50 / bg-sky-50
  - 文字: text-green-700 / text-amber-700 / text-rose-700 / text-sky-700
  - 枠線: ring-1 ring-green-200 / ring-amber-200 / ring-rose-200 / ring-sky-200
- application.html.erb に safelist の partial を末尾で render

## 影響範囲
- hidden 要素のため表示影響なし
- 既存CSS/JSへ副作用なし

## 確認項目
- [ ] ローカルで `bin/rails tailwindcss:build` 実行後、カレンダーセルの色が表示される
- [ ] 本番デプロイ後も同様に色が維持される
