### PR TITLE
feat: カレンダー（モバイル）で状態別のセル背景色を適用 + Tailwind safelist整備

### DIFF
--- a/app/helpers/fasting_records_helper.rb
+++ b/app/helpers/fasting_records_helper.rb
@@ -31,8 +31,8 @@ module FastingRecordsHelper
   # 旧パラメータ(success/failure)との互換
   def normalized_status_param(raw)
     case raw.to_s
-    when "success"   then "achieved"
-    when "failure"   then "unachieved"
+    when "success" then "achieved"
+    when "failure" then "unachieved"
     else raw
     end
   end
@@ -47,12 +47,9 @@ module FastingRecordsHelper
       end
 
     case key
-    when :achieved
-      content_tag(:span, "達成",   class: "badge badge--ok")
-    when :unachieved
-      content_tag(:span, "未達成", class: "badge badge--ng")
-    else
-      content_tag(:span, "進行中", class: "badge badge--info")
+    when :achieved   then content_tag(:span, "達成",   class: "badge badge--ok")
+    when :unachieved then content_tag(:span, "未達成", class: "badge badge--ng")
+    else                  content_tag(:span, "進行中", class: "badge badge--info")
     end
   end
 
@@ -77,33 +74,25 @@ module FastingRecordsHelper
 
   # ===== カレンダー用 =====
 
-  # モバイルだけ「正方形」にするための外側ラッパー（aタグ）用クラス
-  # - mobile: pb-[100%] で正方形ボックス化（position: relative 前提）
-  # - >=sm: 通常フロー
+  # 外側ラッパー（aタグ）: モバイルは正方形レイアウト
   def day_cell_outer_classes(_day)
     "relative block pb-[100%] sm:pb-0"
   end
 
-  # 内側（実表示）用クラス
-  # - >=sm では従来通りの高さを確保
-  # - ホバー/フォーカスの視認性、今日の薄いリング
+  # 内側（実表示）: base スタイル + todayリング
   def day_cell_classes(day, target_month)
     is_today = (day == Time.zone.today)
 
     base = [
-      # 内側はモバイルで absolute 展開して正方形にフィット
       "absolute inset-0",
       "rounded-xl flex flex-col gap-2 p-2 cursor-pointer",
-      # ベース
       "bg-white ring-1 ring-stone-200 shadow-sm",
-      # 変化
       "transition-colors transition-transform duration-150",
       "hover:bg-sky-50 hover:ring-sky-300 hover:shadow-md hover:shadow-sky-100/60",
       "focus-visible:outline-none focus-visible:bg-sky-50",
       "focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:shadow-lg",
       "active:bg-sky-100 active:shadow",
       "hover:-translate-y-[1px] active:scale-[0.99] motion-reduce:transform-none",
-      # デスクトップでは最低高を確保
       "sm:static sm:min-h-[96px]"
     ]
     base << "ring-sky-200" if is_today
@@ -112,8 +101,9 @@ module FastingRecordsHelper
     day.month == target_month ? "#{klass} text-stone-800" : "#{klass} text-stone-400"
   end
 
-  # モバイル幅でセル背景色を状態別に変える（PC幅では白背景に戻す）
-  # - 達成=淡い緑 / 途中=淡い黄 / 未達=淡い赤
+  # モバイル幅でセル背景色を状態別に変える（PC幅では白に戻す）
+  # 達成=bg-green-50 / 途中=bg-amber-50 / 未達=bg-rose-50
+  # 併せて ring 色も薄く寄せる（PCでは stone に戻す）
   def mobile_color_classes(record)
     return "" unless record
 
@@ -126,7 +116,7 @@ module FastingRecordsHelper
     end
   end
 
-  # 旧来の◯/△/×バッジ（PCの凡例やPCセル内表示で使用）
+  # 旧来の◯/△/×バッジ（凡例やPCセル内表示）
   def fasting_badge_for(record)
     return if record.nil?
 

--- a/app/views/fasting_records/calendar.html.erb
+++ b/app/views/fasting_records/calendar.html.erb
@@ -53,7 +53,7 @@
               <% end %>
             </div>
 
-            <!-- 下段：PCのみバッジ表示 / モバイルは非表示（情報量削減） -->
+            <!-- 下段：PCのみバッジ表示 / モバイルは非表示 -->
             <% if record %>
               <div class="mt-1 hidden sm:block"><%= fasting_badge_for(record) %></div>
             <% else %>
@@ -66,7 +66,7 @@
       <% end %>
     </div>
 
-    <!-- 凡例（PC向け表示想定） -->
+    <!-- 凡例（PC向け） -->
     <div class="mt-6 flex flex-wrap items-center gap-3 text-[12px] text-stone-800">
       <span class="inline-flex items-center gap-1">
         <span class="inline-block w-5"><%= tailwind_badge("◯", "bg-green-100 text-green-700 ring-green-200") %></span> 成功

--- a/app/views/shared/_tw_safelist.html.erb
+++ b/app/views/shared/_tw_safelist.html.erb
@@ -1,20 +1,22 @@
-<%# Tailwind safelist（hidden）: 本番ビルドでパージされないように強制含有 %>
-<div class="hidden">
-  <!-- 背景色（セル用） -->
-  <span class="bg-green-100"></span>
-  <span class="bg-amber-100"></span>
-  <span class="bg-rose-100"></span>
-  <span class="bg-sky-50"></span>
+<%# app/views/shared/_tw_safelist.html.erb %>
+<template hidden>
+  <!-- 背景色（モバイルのセル背景） -->
+  <span class="bg-green-50"></span>
+  <span class="bg-amber-50"></span>
+  <span class="bg-rose-50"></span>
+  <span class="bg-white"></span>
 
-  <!-- 文字色（todayやPC表示で使用） -->
-  <span class="text-green-700"></span>
-  <span class="text-amber-700"></span>
-  <span class="text-rose-700"></span>
+  <!-- 文字色（todayや凡例など） -->
   <span class="text-sky-700"></span>
+  <span class="text-stone-900"></span>
+  <span class="text-stone-500"></span>
 
-  <!-- 枠線色（ring-*） -->
+  <!-- 枠線（ring） -->
   <span class="ring-1 ring-green-200"></span>
   <span class="ring-1 ring-amber-200"></span>
   <span class="ring-1 ring-rose-200"></span>
-  <span class="ring-1 ring-sky-200"></span>
-</div>
+  <span class="ring-1 ring-stone-200"></span>
+
+  <!-- レスポンシブ指定を拾わせる（sm:系はクラス文字列ごと必要） -->
+  <div class="sm:bg-white sm:ring-stone-200"></div>
+</template>


### PR DESCRIPTION
## 目的
モバイル表示で「◯/△/×」のバッジではなく、セル背景色のみで直感的に状態が分かるようにする。
PC表示は従来どおり白背景＋凡例。

## 変更点
- helper: `mobile_color_classes(record)` を追加（達成=green-50 / 途中=amber-50 / 未達=rose-50、PCでは白へ戻す）
- view(calendar): `day_cell_classes` と `mobile_color_classes` を併用してセルに背景色を付与
- build: `app/views/shared/_tw_safelist.html.erb` を実装クラスに合わせて更新（bg-*-50 / ring-stone-200 / sm:プレフィックス等）

## 動作確認
- モバイル幅: 記録ありセルが淡色背景になり、見やすくなる
- PC幅: セルは白背景のまま、凡例で状態を表示
- Rubocop: OK
