### PR TITLE
fix: PostgreSQLでのUIDバックフィルに対応（pgcrypto/gen_random_uuid）Closes #166

### DIFF
--- a/db/migrate/20251110092826_add_uid_to_fasting_records.rb
+++ b/db/migrate/20251110092826_add_uid_to_fasting_records.rb
@@ -1,17 +1,28 @@
-# db/migrate/XXXXXXXXXXXXXX_add_uid_to_fasting_records.rb
 class AddUidToFastingRecords < ActiveRecord::Migration[7.2]
   def up
-    # 一旦NULL許可で追加 → バックフィル → NOT NULL化
+    # 一旦 NULL 許可 → バックフィル → NOT NULL 化
     add_column :fasting_records, :uid, :binary, limit: 16, null: true, comment: "Public UUID (binary16)"
     add_index  :fasting_records, :uid, unique: true
 
-    # 既存データ全件にUUID(16バイト)を付与
-    # MySQL: UUID() を 32hex に → REPLACEで'-'除去 → UNHEXで16バイトへ
-    execute <<~SQL.squish
-      UPDATE fasting_records
-         SET uid = UNHEX(REPLACE(UUID(),'-',''))
-       WHERE uid IS NULL;
-    SQL
+    case adapter
+    when :mysql
+      # MySQL/MariaDB
+      execute <<~SQL.squish
+        UPDATE fasting_records
+           SET uid = UNHEX(REPLACE(UUID(),'-',''))
+         WHERE uid IS NULL;
+      SQL
+    when :postgres
+      # PostgreSQL: pgcrypto の gen_random_uuid() を使用
+      enable_extension "pgcrypto" unless extension_enabled?("pgcrypto")
+      execute <<~SQL.squish
+        UPDATE fasting_records
+           SET uid = decode(replace(gen_random_uuid()::text, '-', ''), 'hex')
+         WHERE uid IS NULL;
+      SQL
+    else
+      raise "Unsupported adapter for UID backfill: #{ActiveRecord::Base.connection.adapter_name}"
+    end
 
     change_column_null :fasting_records, :uid, false
   end
@@ -19,5 +30,14 @@ class AddUidToFastingRecords < ActiveRecord::Migration[7.2]
   def down
     remove_index  :fasting_records, :uid
     remove_column :fasting_records, :uid
+  end
+
+  private
+
+  def adapter
+    name = ActiveRecord::Base.connection.adapter_name.downcase
+    return :postgres if name.include?("postgres")
+    return :mysql    if name.include?("mysql")
+    :unknown
   end
 end


### PR DESCRIPTION
## 概要
本番が PostgreSQL のため、MySQL 用の `UUID()/UNHEX()` を使ったバックフィルが失敗していました。  
DBアダプタを判定して **PostgreSQL では `pgcrypto` の `gen_random_uuid()`** を用い、  
`decode(replace(...), 'hex')` で BINARY(16) に格納する方式へ修正しました。

Closes #166

## 変更点
- migration: `AddUidToFastingRecords`
  - アダプタ判定（mysql / postgres）
  - **postgres:** `enable_extension "pgcrypto"` → `gen_random_uuid()` → `decode(replace(...), 'hex')`
  - **mysql:** 既存の `UUID()` / `UNHEX()` を維持
- 既存の `NOT NULL` / `UNIQUE INDEX` はそのまま

## 動作確認
- Render(本番) で `bundle exec rails db:migrate` が成功することを確認予定
- データ検査（メモ）:
  ```bash
  bundle exec rails runner 'puts({null: FastingRecord.where(uid:nil).count, total: FastingRecord.count, distinct: FastingRecord.distinct.count(:uid)}.to_json)'
