### PR TITLE
Landing: ヒーローの縦リズム/下寄せを調整し1画面収まりを最適化 Close #167

### DIFF
--- a/app/assets/stylesheets/landing.css
+++ b/app/assets/stylesheets/landing.css
@@ -19,7 +19,7 @@
     --mint-700: #1da391; /* active */
     --mint-ring: rgba(73, 216, 183, 0.35);
 
-    /* Login outline color（ログイン/Google で共通化） */
+    /* Login outline color（ログイン/Google 共通） */
     --login-outline: #2bb7a9;
   }
   @media (min-width: 768px) {
@@ -75,19 +75,36 @@
 
 /* =============== Landing Hero（トップの中身） =============== */
 @layer components {
-  /* ヒーロー全体（min-height は 1 箇所に統一） */
+  /* ヒーロー全体（基本） */
   body.landing-root .hero{
     position: relative;
     display: flex;
-    align-items: center;
+    align-items: center;          /* 中央寄せ（デフォルト） */
     justify-content: center;
     min-height: 74svh;
     padding-block: clamp(16px, 4vh, 40px);
-    /* ノッチ & 固定ヘッダー保険 */
     padding-top: calc(env(safe-area-inset-top, 0px) + 8px);
   }
 
-  /* コンテンツ内側 */
+  /* --- Modifiers -------------------------------------------------- */
+
+  /* 余白と縦サイズをややコンパクトに */
+  body.landing-root .hero.hero--compact{
+    min-height: 68svh;
+    padding-block: clamp(12px, 3vh, 28px);
+  }
+
+  /* タイトル上寄せ：ヒーローの縦位置を上に、見出しを早めに表示 */
+  body.landing-root .hero.hero--title-top{
+    align-items: flex-start;                     /* 上寄せ */
+    justify-content: center;
+    padding-top: clamp(20px, 7vh, 56px);        /* 上の余白（≒ mt-5〜mt-16） */
+  }
+  body.landing-root .hero.hero--title-top .hero__title{
+    margin-top: 0;                               /* 余計な空き防止 */
+  }
+
+  /* コンテンツ内側（縦フレックス＋可変ギャップ） */
   body.landing-root .hero__inner{
     position: relative;
     z-index: 1;
@@ -95,8 +112,16 @@
     max-width: 980px;
     margin-inline: auto;
     padding-inline: clamp(16px, 4vw, 32px);
-    text-align: center;
     color: #111;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    /* 全体の縦リズムを画面幅で可変化 */
+    --stack-gap: clamp(10px, 2.2vw, 20px);
+    gap: var(--stack-gap);
+    text-align: center;
   }
 
   /* タイトル（Fasty は太字・白・影） */
@@ -110,12 +135,12 @@
       0 0 1px rgba(255,255,255,.35);
     filter: drop-shadow(0 8px 14px rgba(0,0,0,.35));
     user-select: none;
-    margin: 0 0 1rem;
+    margin: 0 0 clamp(8px, 1.8vw, 14px);  /* ロゴ下の余白も可変 */
   }
 
-  /* キャッチコピー：太字・読みやすい影 */
+  /* キャッチコピー：余白を少し詰める＆読みやすい影 */
   body.landing-root .hero__kicker{
-    margin-top: .75rem;
+    margin-top: 0;
     font-weight: 800;
     line-height: 1.6;
     font-size: clamp(1.15rem, 2.6vw, 1.6rem);
@@ -124,69 +149,19 @@
       0 0 10px rgba(255,255,255,.28);
   }
 
-  /* ===== Hero bullets（スマホ見栄えアップ） ===== */
-
-  /* 1) 自然な改行＆日本語の不自然分割を防ぐ */
-  body.landing-root .hero__bullets{
-    margin: .8rem auto 0;
-    padding: 0;
-    list-style: none;
-    display: grid;
-    gap: .55rem;
-    font-weight: 400;
-    font-size: clamp(1.05rem, 2.1vw, 1.35rem);
-    line-height: 1.7;
-    text-shadow:
-      0 1px 0 rgba(255,255,255,.80),
-      0 0 8px rgba(255,255,255,.22);
-
-    text-wrap: balance;
-    word-break: keep-all;
-    letter-spacing: .01em;
-  }
-
-  /* 2) “✅”をぶら下げインデントにして、2行目以降が揃う */
-  body.landing-root .hero__bullets li{
-    text-indent: 0;
-    padding-left: 0;
-  }
-
-  /* 3) 超狭幅で少しだけコンパクトに＆行長を制御 */
-  @media (max-width: 380px){
-    body.landing-root .hero__bullets{
-      gap: .45rem;
-      line-height: 1.6;
-      max-width: 26ch;
-      margin-inline: auto;
-    }
-  }
-
-  /* 4) さらに狭い端末向けの保険（任意） */
-  @media (max-width: 350px){
-    body.landing-root .hero__bullets{
-      font-size: clamp(1.00rem, 3.0vw, 1.15rem);
-    }
-  }
-
-  /* 5) モーション軽減設定に追従（影だけ少し控えめ） */
-  @media (prefers-reduced-motion: reduce){
-    body.landing-root .hero__bullets{
-      text-shadow: 0 1px 0 rgba(255,255,255,.75);
-    }
-  }
-
-  /* 注意書き：控えめ */
-  body.landing-root .hero__note{
-    margin-top: .75rem;
-    font-size: clamp(12px, 1.3vw, 13px);
-    line-height: 1.6;
-    opacity: .95;
-    text-shadow: 0 1px 0 rgba(255,255,255,.75), 0 0 6px rgba(255,255,255,.18);
+  /* ===== CTAとGoogleを“ひとまとめ”にして下寄せ ===== */
+  body.landing-root .hero__actions{
+    margin-top: auto;                           /* 空きを吸って下に着地 */
+    padding-bottom: clamp(16px, 6vh, 56px);     /* 画面高に応じて自然な下余白 */
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(10px, 2vw, 16px);
   }
 
   /* CTA（2ボタン） */
   body.landing-root .hero__cta{
-    margin-top: clamp(18px, 2.8vw, 26px);
+    margin-top: clamp(12px, 2.6vw, 22px);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -194,7 +169,7 @@
     flex-wrap: wrap;
   }
 
-  /* 2ボタン共通：内容幅にフィット（min-width 撤廃） */
+  /* 2ボタン共通：内容幅にフィット */
   body.landing-root .hero__cta .btn-hero{
     display: inline-flex;
     align-items: center;
@@ -219,9 +194,7 @@
                 background-color .15s ease, color .15s ease, border-color .15s ease;
     max-width: 90vw;
   }
-  body.landing-root .hero__cta .btn-hero:active{
-    transform: scale(.99);
-  }
+  body.landing-root .hero__cta .btn-hero:active{ transform: scale(.99); }
 
   /* 新規登録（塗り） */
   body.landing-root .hero__cta .btn-mint.btn-hero{
@@ -249,7 +222,6 @@
     display: flex;
     justify-content: center;
   }
-
   body.landing-root .hero__oauth .btn-google{
     appearance: none;
     display: inline-flex;
@@ -276,68 +248,63 @@
     transform: translateY(0);
     box-shadow: none;
   }
-  body.landing-root .hero__oauth .btn-google .g-icon{
-    width: 20px; height: 20px;
-  }
-  body.landing-root .hero__oauth .btn-google .text{
-    font-size: 16px;
-  }
+  body.landing-root .hero__oauth .btn-google .g-icon{ width: 20px; height: 20px; }
+  body.landing-root .hero__oauth .btn-google .text{ font-size: 16px; }
 
-  /* アニメ軽減設定に合わせてモーションを弱める */
+  /* アニメ軽減設定 */
   @media (prefers-reduced-motion: reduce){
-    body.landing-root .hero__cta .btn-hero{
-      transition: none;
-    }
-    body.landing-root .hero__cta .btn-hero:hover{
-      transform: none;
-      box-shadow: 0 0 0 rgba(0,0,0,0);
-    }
-    body.landing-root .hero__oauth .btn-google{
-      transition: none;
-    }
-    body.landing-root .hero__oauth .btn-google:hover{
-      transform: none;
-      box-shadow: 0 0 0 rgba(0,0,0,0);
-    }
+    body.landing-root .hero__cta .btn-hero,
+    body.landing-root .hero__oauth .btn-google{ transition: none; }
+    body.landing-root .hero__cta .btn-hero:hover{ transform: none; box-shadow: 0 0 0 rgba(0,0,0,0); }
+    body.landing-root .hero__oauth .btn-google:hover{ transform: none; box-shadow: 0 0 0 rgba(0,0,0,0); }
   }
 }
-
 /* ====== MyPage：やさしいグラデ背景（下地を生かす半透明オーバーレイ） ====== */
 @layer components {
-  .mypage-bg {
+  /* 背景の土台（高さは強制しない） */
+  .mypage-bg{
     position: relative;
-    min-height: 100svh;
     background: transparent; /* ← body::before の画像を生かす */
   }
 
-  .mypage-bg::before {
-    content: "";
-    position: fixed;
-    inset: 0;
-    z-index: -1;              /* body::after(-2) より手前に出ない */
-    pointer-events: none;
+  /* “常に下まで満たしたい”画面だけこれを追加で付ける */
+  .mypage-bg--full{ min-height: 100svh; }
 
-    /* α を弱めて下の画像を生かす */
+  /* 今回のマイページは自然に詰めたいのでこちらを付ける */
+  .mypage-bg--compact{
+    /* 高さは強制しない。フッターと喧嘩しないよう下だけ少し余白 */
+    padding-bottom: clamp(16px, 6vh, 40px);
+  }
+
+  /* 背景のやさしいベール */
+  .mypage-bg::before{
+    content:"";
+    position: fixed; inset: 0;
+    z-index: -1;                /* body::after(-2) より手前に出ない */
+    pointer-events: none;
     background:
-      radial-gradient(
-        1100px 520px at 50% 0%,
+      radial-gradient(1100px 520px at 50% 0%,
         rgba(59,130,246,0.04) 0%,
-        rgba(59,130,246,0.00) 62%
-      ),
-      linear-gradient(
-        180deg,
+        rgba(59,130,246,0.00) 62%),
+      linear-gradient(180deg,
         rgba(250,250,250,0.40) 0%,
         rgba(247,245,242,0.22) 58%,
-        rgba(244,241,237,0.18) 100%
-      );
+        rgba(244,241,237,0.18) 100%);
+  }
+
+  /* 中身の“縦リズム”を一元管理（画面幅で可変） */
+  .mypage-stack{
+    display: flex;
+    flex-direction: column;
+    gap: clamp(10px, 2.2vw, 18px);
   }
 
   /* ==== Mint button（汎用） =============================== */
   .btn-mint{
     background-color: var(--mint-500);
     color: #fff;
-    border-radius: 0.75rem; /* rounded-xl 的な */
-    padding: 0.75rem 1.5rem; /* btn-lg に寄せる */
+    border-radius: 0.75rem;
+    padding: 0.75rem 1.5rem;
     font-weight: 700;
     box-shadow: 0 6px 14px rgba(0,0,0,0.08);
     transition: background-color .15s ease, transform .06s ease, box-shadow .15s ease;
@@ -347,6 +314,7 @@
   .btn-mint:disabled{ opacity: .6; cursor: not-allowed; }
   .btn-mint:focus-visible{ outline: 3px solid var(--mint-ring); outline-offset: 2px; }
 }
+
 /* ===== Devise: OAuth button (Google) =================== */
 
 /* デフォは左寄せ */
@@ -405,7 +373,7 @@
   outline-offset:2px;
 }
 
-/* ---------- 枠なし（ゴースト）版：外枠を消して軽く見せる ---------- */
+/* ---------- 枠なし（ゴースト）版 ---------- */
 .oauth-btn--google.oauth-btn--borderless{
   border-color:transparent;
   background:transparent;
@@ -423,14 +391,8 @@
 }
 
 /* ---------- アイコン＆ラベル ---------- */
-.oauth-btn__icon{
-  display:inline-flex;
-  width:18px; height:18px; flex:0 0 18px;
-}
-.oauth-btn__label{
-  font-size:15px;
-  font-weight: 500;
-}
+.oauth-btn__icon{ display:inline-flex; width:18px; height:18px; flex:0 0 18px; }
+.oauth-btn__label{ font-size:15px; font-weight: 500; }
 
 /* 無効時 */
 .oauth-btn:disabled{
@@ -449,4 +411,11 @@
 @media (max-width:420px){
   .devise-oauth{ padding-inline:0; }
   .oauth-btn{ width:100%; justify-content:center; }
+}
+
+/* 極小幅の保険（ヒーロー関連があれば維持） */
+@media (max-width:380px){
+  body.landing-root .hero__inner{ --stack-gap: 12px; }
+  body.landing-root .hero__cta{ margin-top: 16px; }
+  body.landing-root .hero__actions{ padding-bottom: 20px; }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
     <!-- CSS (Sprockets/Tailwind) -->
     <%= stylesheet_link_tag "tailwind", "application", "layout", "drawer", "landing", "devise", "data-turbo-track": "reload" %>
 
-    <!-- 画面個別で <head> 追記したい場合に使用 -->
+    <!-- 画面個別で <head> 追記 -->
     <%= yield :head %>
 
     <!-- JS (importmap) -->
@@ -23,12 +23,12 @@
 
     <!-- PWA / Icons -->
     <link rel="manifest" href="/manifest.webmanifest">
-    <link rel="icon" href="/icon.svg" type="image/svg+xml"><!-- SVG優先 -->
-    <link rel="icon" href="/icon.png" type="image/png"><!-- フォールバック -->
+    <link rel="icon" href="/icon.svg" type="image/svg+xml">
+    <link rel="icon" href="/icon.png" type="image/png">
     <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png">
 
     <%# ================================
-       OGP / Twitter Card（デフォルト + 上書き対応）
+       OGP / Twitter Card（デフォルト + 上書き）
        ================================= %>
     <% meta = default_meta %>
     <% page_title       = content_for?(:title)       ? yield(:title)       : meta[:title] %>
@@ -81,8 +81,8 @@
         <%= render "shared/flash" %>
       </div>
 
-      <!-- ▼ 共通コンテナ -->
-      <div class="mx-auto w-full max-w-screen-lg px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
+      <!-- ▼ 共通コンテナ（ランディング等はフルブリード可） -->
+      <div class="app-container mx-auto w-full max-w-screen-lg px-4 sm:px-6 lg:px-8 py-6 sm:py-8 <%= 'is-full-bleed' if content_for?(:full_bleed) %>">
         <%= yield %>
       </div>
     </main>

--- a/app/views/mypages/show.html.erb
+++ b/app/views/mypages/show.html.erb
@@ -1,24 +1,20 @@
 <%# app/views/mypages/show.html.erb %>
+<div class="mypage-bg mypage-bg--compact">
+  <!-- 中身の縦リズムを可変で統一 -->
+  <div class="mypage-stack max-w-3xl mx-auto px-6 pt-3 pb-4">
 
-<div class="mypage-bg">
-  <!-- 上余白はコンパクトに（pt-0）。セクション間も少しだけ詰める -->
-  <div class="relative max-w-3xl mx-auto px-6 pt-0 pb-0 space-y-4 sm:space-y-5">
-
-    <!-- ▼ 挨拶バー：ヘッダー直下から少しだけ間を空ける（mt-5） -->
-    <div class="mt-5 sm:mt-6">
+    <!-- 挨拶バー -->
+    <div class="mt-3 sm:mt-4">
       <%= render "shared/greeting", user: current_user %>
     </div>
 
     <% title_text, kind = fasting_hero(current_user) %>
 
-    <!-- ステータスメッセージ：ヘッダー同色＋白文字／ドットのみ -->
+    <!-- ステータスバッジ -->
     <div class="flex justify-center">
-      <div class="<%= hero_class_for(kind, theme: :neutral) %>"
-           role="region" aria-label="ステータスメッセージ">
+      <div class="<%= hero_class_for(kind, theme: :neutral) %>" role="region" aria-label="ステータスメッセージ">
         <span class="w-2.5 h-2.5 rounded-full <%= status_dot_color(kind) %>"></span>
-        <h1 class="text-base sm:text-lg font-extrabold tracking-wide leading-snug">
-          <%= title_text %>
-        </h1>
+        <h1 class="text-base sm:text-lg font-extrabold tracking-wide leading-snug"><%= title_text %></h1>
       </div>
     </div>
 
@@ -27,9 +23,7 @@
     </div>
 
     <% if @running&.target_hours.present? %>
-      <div class="text-gray-700">
-        目標時間：<strong><%= @running.target_hours %>時間</strong>
-      </div>
+      <div class="text-gray-700">目標時間：<strong><%= @running.target_hours %>時間</strong></div>
     <% end %>
 
     <% if @running.present? %>
@@ -37,21 +31,18 @@
       <div class="rounded-lg border p-4 sm:p-5 space-y-3 bg-white/70">
         <div class="flex items-center gap-3 text-lg sm:text-xl">
           <span class="text-2xl sm:text-3xl">🕒</span>
-          <span
-            data-controller="timer"
-            data-timer-start-at-value="<%= @running.start_time.to_i %>"
-            class="font-mono text-2xl sm:text-3xl align-middle">00:00:00</span>
+          <span data-controller="timer"
+                data-timer-start-at-value="<%= @running.start_time.to_i %>"
+                class="font-mono text-2xl sm:text-3xl align-middle">00:00:00</span>
         </div>
         <div class="text-sm text-gray-600">開始：<%= l @running.start_time %></div>
         <div class="text-right">
-          <%= link_to "瞑想で心を整える",
-                      meditations_path,
-                      class: "text-sky-600 underline text-sm font-semibold" %>
+          <%= link_to "瞑想で心を整える", meditations_path, class: "text-sky-600 underline text-sm font-semibold" %>
         </div>
       </div>
 
-      <!-- 終了ボタン：テキスト幅にフィット -->
-      <div class="mt-6 sm:mt-8 mb-0 flex justify-center">
+      <!-- 終了ボタン：ややタイトに -->
+      <div class="mt-5 sm:mt-6 mb-2 flex justify-center">
         <%= button_to "ファスティング終了",
               finish_fasting_record_path(@running),
               method: :post,
@@ -71,10 +62,8 @@
                 class: "border rounded px-3 py-2 w-full max-w-xs" %>
         </div>
 
-        <!-- 開始ボタン：テキスト幅にフィット -->
         <div class="pt-1 mb-1 sm:mb-0 flex justify-center">
-          <%= submit_tag "ファスティング開始",
-                class: "btn-mint btn-lg btn-wrap" %>
+          <%= submit_tag "ファスティング開始", class: "btn-mint btn-lg btn-wrap" %>
         </div>
       <% end %>
     <% end %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,26 +1,30 @@
-<section class="hero">
+<!-- app/views/pages/home.html.erb -->
+
+<%# レイアウトの共通コンテナをフルブリードにするフラグ %>
+<% content_for :full_bleed, true %>
+
+<section class="hero hero--compact hero--title-top hero--fluid-stack">
   <div class="hero__inner">
+    <!-- タイトル -->
     <h1 class="hero__title">Fasty</h1>
-    <p class="hero__kicker">ファスティング × 瞑想で<br>内側からきれいを育てる。</p>
 
-    <ul class="hero__bullets">
-      <li>✅ 空腹時間をつくって、からだをリセット</li>
-      <li>✅ 5分からの瞑想で、心も整う</li>
-      <li>✅ 最短12時間からの目標で無理なく継続</li>
-    </ul>
+    <!-- キッカー（PCでも改行） -->
+    <p class="hero__kicker">
+      ファスティング × 瞑想で<br>
+      内側からきれいを育てる。
+    </p>
 
-    <p class="hero__note">※体感には個人差があります。本アプリは医療サービスではありません。</p>
+    <!-- ↓ CTA群をひとまとめ（下寄せ・スタック調整の対象） -->
+    <div class="hero__actions">
+      <div class="hero__cta">
+        <%= link_to "新規登録", new_user_registration_path, class: "btn-hero btn-mint" %>
+        <%= link_to "ログイン", new_user_session_path, class: "btn-hero btn-hero--login" %>
+      </div>
 
-    <div class="hero__cta">
-      <%= link_to "新規登録", new_user_registration_path,
-            class: "btn-hero btn-mint" %>
-      <%= link_to "ログイン", new_user_session_path,
-            class: "btn-hero btn-hero--login" %>
+      <div class="hero__oauth">
+        <%= render "shared/google_sign_in" %>
+      </div>
     </div>
-
-    <!-- Googleでログイン（下段・中央寄せ） -->
-    <div class="hero__oauth mt-4 flex justify-center">
-      <%= render "shared/google_sign_in" %>
-    </div>
+    <!-- ↑ まとめ終わり -->
   </div>
 </section>


### PR DESCRIPTION
## 概要
- ランディング（/）とマイページの余白・縦リズムを調整し、スマホ/PCともに1画面内で自然に収まるよう最適化
- 共通レイアウトのコンテナをランディングでは外し、ヒーロー専用の可変スタックを導入

## 変更点
- `landing.css`
  - `.hero__inner` を縦Flex化 + `--stack-gap`（clamp）で要素間の余白を可変
  - `.hero__actions { margin-top:auto; padding-bottom:clamp(...) }` でCTA群を下寄せ
  - タイトル上寄せの余白を `clamp` で最適化
- `app/views/pages/home.html.erb`
  - CTA と Google ボタンを `.hero__actions` に集約
  - ヒーロー用の modifier クラスを適用
- `app/views/layouts/application.html.erb`
  - ランディング時は共通コンテナの影響を受けないよう整理
- `app/views/mypages/show.html.erb`
  - 余白をコンパクト化（pt/mtの見直し）してフッターまでの無駄な空白を削減

## 動作確認
- iPhone 13/Pro Max, Pixel 7, iPad, 1440px/1920px で表示確認
- 1画面にフッターが収まる（ランディング）/ スクロール量の適正化（マイページ）

## 影響範囲
- トップ（/）, マイページ（/mypage）, 共通レイアウト
  - 他画面のコンテナ幅には影響なし

## 関連
- Close #167
