### PR TITLE
LP: 効果セクション下にCTA配置 & ヒーロー調整（_lp_effects追加）

### DIFF
--- a/app/assets/stylesheets/landing.css
+++ b/app/assets/stylesheets/landing.css
@@ -85,7 +85,11 @@
     padding-top: calc(env(safe-area-inset-top, 0px) + 8px);
   }
   body.landing-root .hero.hero--compact{ min-height:68svh; padding-block:clamp(12px,3vh,28px); }
-  body.landing-root .hero.hero--title-top{ align-items:flex-start; justify-content:center; padding-top:clamp(20px,7vh,56px); }
+
+  /* タイトルを上寄せ（配置のみ） */
+  body.landing-root .hero.hero--title-top{
+    align-items:flex-start; justify-content:center; padding-top:clamp(20px,7vh,56px);
+  }
   body.landing-root .hero.hero--title-top .hero__title{ margin-top:0; }
 
   body.landing-root .hero__inner{
@@ -95,13 +99,8 @@
     --stack-gap: clamp(10px, 2.2vw, 20px); gap: var(--stack-gap);
   }
 
-  body.landing-root .hero__title{
-    color:#fff; font-weight:800; letter-spacing:.06em; font-size:clamp(2.6rem,6vw,4rem);
-    text-shadow: 0 10px 22px rgba(0,0,0,.35), 0 0 1px rgba(255,255,255,.35);
-    filter: drop-shadow(0 8px 14px rgba(0,0,0,.35));
-    user-select:none;
-    margin:0 0 clamp(8px,1.8vw,14px);
-  }
+  /* ▼ 見た目は Tailwind ユーティリティで指定するため、装飾は持たない */
+  body.landing-root .hero__title{ margin:0; user-select:none; }
 
   body.landing-root .hero__kicker{
     margin-top:0; font-weight:800; line-height:1.6; font-size:clamp(1.15rem,2.6vw,1.6rem);

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -7,39 +7,56 @@
 
 <section class="hero hero--compact hero--title-top hero--fluid-stack">
   <div class="hero__inner">
-    <!-- ロゴタイトル -->
-    <h1 class="hero__title">Fasty</h1>
+    <!-- ロゴタイトル（柔らかグラデーション版） -->
+    <h1 class="hero__title -mt-1 sm:-mt-2 md:-mt-3
+               font-extrabold leading-[1.06] tracking-[.01em]
+               text-[clamp(42px,8.2vw,80px)]
+               bg-gradient-to-r from-emerald-400 via-teal-300 to-emerald-400
+               bg-clip-text text-transparent
+               drop-shadow-[0_8px_22px_rgba(16,185,129,0.18)]">
+      Fasty
+    </h1>
 
     <!-- キャッチコピー（SPも改行） -->
-    <p class="hero__kicker">
+    <p class="hero__kicker !font-semibold">
       ファスティング × 瞑想で<br>
       内側からきれいを育てる。
     </p>
 
     <!-- アクション -->
     <div class="hero__actions">
-      <!-- 主役だけ“ボタン” -->
-      <div class="hero__cta">
-        <%= link_to "アプリの使い方", guide_path,
-              class: "btn-hero btn-hero--login",
-              aria: { label: "アプリの使い方を開く" } %>
+      <%# ▼ 効果セクション（CTAはパーシャルの末尾に移動済み） %>
+      <div class="mt-8 md:mt-10 w-full">
+        <%= render "shared/lp_effects" %>
       </div>
 
-      <!-- 他は“テキストリンク”（ミント） -->
-      <nav class="hero__links" aria-label="アカウント操作">
-        <%= link_to "新規登録", new_user_registration_path, class: "hero-link" %>
-        <span class="sep" aria-hidden="true">・</span>
-        <%= link_to "ログイン", new_user_session_path, class: "hero-link" %>
-        <span class="sep" aria-hidden="true">・</span>
+      <%# ▼ アカウント操作：三連ボタン（SP=縦積み / SM+=横並び） %>
+      <div class="mt-6 md:mt-8 flex flex-col sm:flex-row items-center justify-center gap-3 w-full">
+        <!-- 新規登録：「無料で始める」と同じ btn-mint -->
+        <%= link_to new_user_registration_path,
+              class: "btn-mint w-full sm:w-auto inline-flex items-center justify-center rounded-xl px-6 py-3 text-[15px] font-semibold
+                      focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-emerald-400" do %>
+          新規登録
+        <% end %>
 
-        <%# Googleでログイン（公式Gロゴ付き）: POSTで送る %>
+        <!-- ログイン：文字色をミントに（btn-mint背景の系統） -->
+        <%= link_to new_user_session_path,
+              class: "w-full sm:w-auto inline-flex items-center justify-center rounded-xl px-6 py-3 text-[15px] font-semibold
+                      bg-white text-emerald-400 ring-1 ring-emerald-300 hover:bg-white/90 shadow-sm
+                      focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-emerald-300" do %>
+          ログイン
+        <% end %>
+
+        <!-- Googleでログイン：同じくミント文字＋白背景（POST） -->
         <%= button_to user_google_oauth2_omniauth_authorize_path,
               method: :post,
               form:  { class: "inline", data: { turbo: false } },
-              class: "hero-link hero-link--google",
+              class: "w-full sm:w-auto inline-flex items-center justify-center gap-2 rounded-xl px-6 py-3 text-[15px] font-semibold
+                      bg-white text-emerald-400 ring-1 ring-emerald-300 hover:bg-white/90 shadow-sm
+                      focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-emerald-300",
               aria:  { label: "Googleでログイン" } do %>
-          <span class="g-icon" aria-hidden="true">
-            <!-- Google 'G' logo (official multicolor mark) -->
+          <span class="inline-flex -ml-0.5" aria-hidden="true">
+            <!-- Google 'G' logo（公式マーク） -->
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 262" width="18" height="18" role="img" focusable="false">
               <path fill="#4285F4" d="M255.68 133.5c0-10.7-.86-18.5-2.72-26.6H130.55v48.2h71.72c-1.45 12-9.3 30-26.8 42.2l-.24 1.6 38.9 30 .27.3c25.37-23.4 40.37-57.8 40.37-96.9Z"/>
               <path fill="#34A853" d="M130.55 261.1c36.7 0 67.46-12.1 89.96-32.9l-42.9-33.1c-11.5 8.1-26.9 13.8-47 13.8-35.9 0-66.3-23.9-77.1-56.9l-1.6.1-41.97 32.5-.55.1c22.45 44.6 68.5 76.5 121.66 76.5Z"/>
@@ -47,9 +64,9 @@
               <path fill="#EB4335" d="M130.55 50.2c25.5 0 42.7 11 52.5 20.2l38.3-37.5C197.8 12 167.25 0 130.55 0 77.4 0 31.35 31.9 8.9 76.5l44.45 33.6c10.8-33 41.2-59.9 77.2-59.9Z"/>
             </svg>
           </span>
-          <span class="text">Googleでログイン</span>
+          <span>Googleでログイン</span>
         <% end %>
-      </nav>
+      </div>
     </div>
   </div>
 </section>

--- a/app/views/shared/_lp_effects.html.erb
+++ b/app/views/shared/_lp_effects.html.erb
@@ -1,0 +1,68 @@
+<!-- app/views/shared/_lp_effects.html.erb -->
+<section class="mt-8 px-4 sm:px-6 md:px-8" aria-labelledby="lp-effects">
+  <h2 id="lp-effects" class="sr-only">Fasty の効果セクション</h2>
+
+  <div class="mx-auto max-w-xl sm:max-w-2xl md:max-w-3xl rounded-2xl bg-white/85 backdrop-blur-md shadow-lg ring-1 ring-stone-200 p-4 sm:p-6 md:p-8">
+    <div class="grid gap-4 sm:gap-6 md:grid-cols-2">
+
+      <!-- Fasting -->
+      <article class="rounded-2xl p-4 sm:p-5 md:p-6 bg-emerald-50/80 ring-1 ring-emerald-100 shadow-sm">
+        <header class="flex items-center gap-2">
+          <span class="inline-flex size-7 sm:size-8 items-center justify-center rounded-full bg-emerald-100 ring-1 ring-emerald-200">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4 sm:h-5 sm:w-5" aria-hidden="true">
+              <path d="M20 4c-6 0-10 2-12 4S4 12 4 16c0 2.761 2.239 5 5 5 4 0 6-2 8-4s4-6 4-12Z" fill="currentColor" class="text-emerald-600"/>
+            </svg>
+          </span>
+          <span class="text-[11px] sm:text-xs font-semibold text-emerald-700 bg-emerald-100/90 px-2 py-0.5 rounded-full">ファスティング</span>
+        </header>
+
+        <h3 class="mt-3 text-lg sm:text-xl md:text-2xl font-bold text-stone-800 leading-snug">
+          ファスティングで、心も体もリセット。
+        </h3>
+
+        <p class="mt-2 text-[15px] sm:text-base text-stone-700 leading-relaxed">
+          胃腸を休ませることで代謝が整い、集中力や睡眠の質もアップ。食べない時間を通じて、自分の体と丁寧に向き合うきっかけに。
+        </p>
+
+        <ul class="mt-3 space-y-1.5 text-[14px] sm:text-sm text-stone-700">
+          <li class="flex gap-2"><span class="mt-0.5">✅</span><span>胃腸を休めてスッキリ</span></li>
+          <li class="flex gap-2"><span class="mt-0.5">✅</span><span>集中力・睡眠の質UP</span></li>
+          <li class="flex gap-2"><span class="mt-0.5">✅</span><span>食べ癖をリセット</span></li>
+        </ul>
+      </article>
+
+      <!-- Meditation -->
+      <article class="rounded-2xl p-4 sm:p-5 md:p-6 bg-rose-50/80 ring-1 ring-rose-100 shadow-sm">
+        <header class="flex items-center gap-2">
+          <span class="inline-flex size-7 sm:size-8 items-center justify-center rounded-full bg-rose-100 ring-1 ring-rose-200">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-4 w-4 sm:h-5 sm:w-5" aria-hidden="true">
+              <path d="M12 3c2 3 5 4 7 6-1 5-4 8-7 10C9 17 6 14 5 9c2-2 5-3 7-6Z" fill="currentColor" class="text-rose-600"/>
+            </svg>
+          </span>
+          <span class="text-[11px] sm:text-xs font-semibold text-rose-700 bg-rose-100/90 px-2 py-0.5 rounded-full">瞑想</span>
+        </header>
+
+        <h3 class="mt-3 text-lg sm:text-xl md:text-2xl font-bold text-stone-800 leading-snug">
+          瞑想で、内側から整う。
+        </h3>
+
+        <p class="mt-2 text-[15px] sm:text-base text-stone-700 leading-relaxed">
+          深い呼吸で心が落ち着き、ストレスを手放せる。無駄食いが減り、心身の調和が生まれます。
+        </p>
+
+        <ul class="mt-3 space-y-1.5 text-[14px] sm:text-sm text-stone-700">
+          <li class="flex gap-2"><span class="mt-0.5">🌿</span><span>イライラ・不安をリリース</span></li>
+          <li class="flex gap-2"><span class="mt-0.5">🌿</span><span>食欲の波をやさしく整える</span></li>
+          <li class="flex gap-2"><span class="mt-0.5">🌿</span><span>自分を大切にできる時間</span></li>
+        </ul>
+      </article>
+    </div>
+
+    <!-- ▼ ここが新しいCTA（旧「無料で始める」の位置） -->
+    <div class="pt-6 text-center">
+      <%= link_to "アプリの使い方", guide_path,
+            class: "btn-mint w-full sm:w-auto inline-flex items-center justify-center rounded-xl px-6 py-3 text-base font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-emerald-400",
+            aria: { label: "アプリの使い方を開く" } %>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
このPRでは以下を実施しました。
### 概要

- ヒーロー『Fasty』ロゴを柔らかいミント系グラデに、サイズ微調整
- キャッチコピーを font-semibold に統一
- 効果セクション（_lp_effects）を新規追加し、末尾に『アプリの使い方』CTAを配置
- ログイン/Googleログインの文字色をミント系に統一、ボタン系の視覚階層を整理
- レスポンシブ余白の微調整（sm/md ブレークポイント）

### スクリーンショット
before
<img width="1231" height="667" alt="スクリーンショット 2025-11-12 20 24 53" src="https://github.com/user-attachments/assets/3fd5f72b-f302-41fe-9d28-058e4d1f7bbd" />

after
<img width="1237" height="669" alt="スクリーンショット 2025-11-12 20 25 12" src="https://github.com/user-attachments/assets/d5a135d6-20c0-44a4-a6ce-4b63d35462e6" />

<img width="1233" height="667" alt="スクリーンショット 2025-11-12 20 25 22" src="https://github.com/user-attachments/assets/467d8906-0584-4901-9cf9-fa389213dfe5" />



デプロイ時の補足:
- Tailwind ビルドは本番側のパイプラインで走る想定です（Render の場合はデプロイ時に実行）

Closes #191