### PR TITLE
Meditation Summary: 空データ時の文言削除＆レスポンシブ最終調整

### DIFF
--- a/app/javascript/controllers/chart_daily_controller.js
+++ b/app/javascript/controllers/chart_daily_controller.js
@@ -18,70 +18,9 @@ export default class extends Controller {
     const values  = this.dataValue || [];
     const allZero = values.length > 0 && values.every(v => (v ?? 0) === 0);
 
-    // ===== 空データ時の表示（HiDPI対応＋自動改行＋自動縮小） =====
-    if (allZero) {
-      const c   = ctx;
-      const dpr = window.devicePixelRatio || 1;
-      const rect = this.element.getBoundingClientRect();
+    // 空データ時は描画しない（ビュー側で文言を表示）
+    if (allZero) return;
 
-      // 内部解像度をCSSサイズに合わせる
-      this.element.width  = Math.max(1, Math.floor(rect.width  * dpr));
-      this.element.height = Math.max(1, Math.floor(rect.height * dpr));
-      c.setTransform(dpr, 0, 0, dpr, 0, 0);
-
-      c.clearRect(0, 0, rect.width, rect.height);
-      c.textAlign = "center";
-      c.textBaseline = "middle";
-      c.fillStyle = "rgba(68,64,60,.75)"; // stone-700 相当
-
-      const msg = "まだデータがありません（記録するとグラフが表示されます）";
-
-      // 余白と最大描画領域
-      const padX = Math.max(12, Math.floor(rect.width * 0.05));
-      const padY = Math.max(10, Math.floor(rect.height * 0.08));
-      const boxW = Math.max(1, rect.width  - padX * 2);
-      const boxH = Math.max(1, rect.height - padY * 2);
-
-      // 指定幅に収まるように文字単位で折り返し
-      const wrapLines = (fontPx) => {
-        c.font = `${fontPx}px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial`;
-        const lines = [];
-        let buf = "";
-        for (const ch of msg) {
-          const next = buf + ch;
-          if (c.measureText(next).width > boxW) {
-            lines.push(buf);
-            buf = ch;
-          } else {
-            buf = next;
-          }
-        }
-        if (buf) lines.push(buf);
-        return lines;
-      };
-
-      // フォントサイズを上から下げて、縦横ともに収まるサイズを探索
-      const maxStart = Math.min(18, Math.floor(rect.width / 18)); // 上限（スマホで大きすぎない程度）
-      const minStart = 10;
-      let fontSize = maxStart;
-      let lines    = wrapLines(fontSize);
-      let lineH    = Math.round(fontSize * 1.6);
-
-      while ((lines.length * lineH > boxH || lines.some(t => c.measureText(t).width > boxW)) && fontSize > minStart) {
-        fontSize -= 1;
-        lines  = wrapLines(fontSize);
-        lineH  = Math.round(fontSize * 1.6);
-      }
-
-      // 中央に描画
-      const startY = rect.height / 2 - ((lines.length - 1) * lineH) / 2;
-      lines.forEach((line, i) => c.fillText(line, rect.width / 2, startY + i * lineH));
-
-      return;
-    }
-    // ==========================================================
-
-    // 通常描画（Chart.js）
     this._chart = new Chart(ctx, {
       type: this.hasTypeValue ? this.typeValue : "line",
       data: {

--- a/app/views/meditation_summaries/show.html.erb
+++ b/app/views/meditation_summaries/show.html.erb
@@ -1,3 +1,4 @@
+<!-- app/views/meditation_summaries/show.html.erb -->
 <div class="mx-auto max-w-5xl p-4 md:p-6">
   <div class="flex items-center justify-between gap-3">
     <h1 class="text-2xl md:text-3xl font-semibold">瞑想の履歴</h1>
@@ -35,10 +36,16 @@
     <div class="mt-2 h-56 md:h-64">
       <canvas
         data-controller="chart-daily"
-        data-chart-daily-labels-value="<%= labels.to_json %>"
-        data-chart-daily-data-value="<%= values.to_json %>"
+        data-chart-daily-labels-value="<%= h(labels.to_json) %>"
+        data-chart-daily-data-value="<%= h(values.to_json) %>"
         data-chart-daily-type-value="<%= (@period == :week) ? 'bar' : 'line' %>">
       </canvas>
+      <!-- 画面読上げ向けの補助テキスト（視覚的には非表示） -->
+      <p class="sr-only">
+        <% if values.sum.zero? %>
+          まだグラフに表示するデータがありません。
+        <% end %>
+      </p>
     </div>
   </section>
 


### PR DESCRIPTION
空データ時の「まだデータがありません」文言を削除し、  
PC・モバイル双方でのレイアウト崩れを解消しました。

- Chart.js空データ描画をスキップ
- ビュー構造のレスポンシブ確認済み
- minor spacing and readability tweaks

Refs #198
