### PR TITLE
LPとログイン画面にLINEログインボタンを追加（#169）

### DIFF
--- a/app/assets/stylesheets/devise.css
+++ b/app/assets/stylesheets/devise.css
@@ -12,6 +12,9 @@
   --field-br: 10px;
   --field-bd: 1px solid rgba(0, 0, 0, .12);
   --field-h: 44px;
+
+  /* Fasty ミント（OAuth ボタンの文字色などに使用） */
+  --fasty-mint: #18b8a5;
 }
 
 /* 外側ラッパー：どんな親でも中央寄せにする（ビューで <main class="devise-center"> を使うなら推奨） */
@@ -110,4 +113,71 @@ footer .footer-legal-thin a{ color:#1f4b99 !important; }
 /* スマホ余白最適化 */
 @media (max-width: 480px){
   .devise-wrap{ padding: 16px 14px 32px; }
+}
+
+/* ======================= OAuth ボタン ======================= */
+
+.devise-oauth{
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 18px;
+}
+
+/* ボタン本体（共通） */
+.oauth-btn{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid rgba(0,0,0,.06);
+  background: rgba(255,255,255,.96);
+  box-shadow: 0 8px 22px rgba(0,0,0,.07);
+  cursor: pointer;
+  text-decoration: none;
+  min-width: 230px;
+  transition: box-shadow .18s ease, transform .18s ease, background .18s ease;
+}
+
+.oauth-btn--borderless{
+  border-color: transparent;
+}
+
+/* ホバー時の浮き上がり感 */
+.oauth-btn:hover{
+  transform: translateY(-1px);
+  box-shadow: 0 10px 26px rgba(0,0,0,.09);
+}
+
+/* アイコン部分 */
+.oauth-btn__icon{
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
+
+/* ラベル共通 */
+.oauth-btn__label{
+  font-size: 15px;
+  font-weight: 600;
+}
+
+/* Google / LINE のラベル色をミントで統一 */
+.devise-card .oauth-btn--google .oauth-btn__label,
+.devise-card .oauth-btn--line .oauth-btn__label{
+  color: var(--fasty-mint);
+}
+
+/* LINE ボタン用（必要なら微調整用に定義） */
+.oauth-btn--line{
+  /* ベースは共通スタイルを利用。
+     ここで border や背景を個別に変えたくなったら追加する */
+}
+/* OAuth ラベルをミントにする共通クラス */
+.oauth-btn__label--mint {
+  color: #18b8a5; /* Fasty のミント */
+  font-weight: 600;
 }

--- a/app/assets/stylesheets/landing.css
+++ b/app/assets/stylesheets/landing.css
@@ -220,43 +220,125 @@
   .btn-mint:disabled{ opacity:.6; cursor:not-allowed; }
   .btn-mint:focus-visible{ outline:3px solid var(--mint-ring); outline-offset:2px; }
 }
-
-/* ===== Devise: OAuth button (Google) — 既存のまま ===== */
-.devise-oauth{ display:flex; justify-content:flex-start; align-items:center; margin-top:10px; }
-.devise-oauth--center{ display:flex; justify-content:center; }
+/* ===== Devise: OAuth button (Google / LINE) ===== */
+.devise-oauth{
+  display:flex;
+  justify-content:flex-start;
+  align-items:center;
+  margin-top:10px;
+}
+.devise-oauth--center{
+  display:flex;
+  justify-content:center;
+}
 
 .oauth-btn{
-  display:inline-flex; align-items:center; gap:.55rem; border-radius:9999px;
-  padding:.68rem 1.1rem; font-weight:800; line-height:1; white-space:nowrap;
-  border:2px solid transparent; background:#fff; color:#111; box-shadow:0 10px 24px rgba(0,0,0,.05);
-  transition: transform .12s ease, box-shadow .15s ease, background-color .15s ease, color .15s ease, border-color .15s ease;
+  display:inline-flex;
+  align-items:center;
+  gap:.55rem;
+  border-radius:9999px;
+  padding:.68rem 1.1rem;
+  font-weight:800;
+  line-height:1;
+  white-space:nowrap;
+  border:2px solid transparent;
+  background:#fff;
+  color:#111;
+  box-shadow:0 10px 24px rgba(0,0,0,.05);
+  transition:
+    transform .12s ease,
+    box-shadow .15s ease,
+    background-color .15s ease,
+    color .15s ease,
+    border-color .15s ease;
 }
-.oauth-btn--google{ color:#2bb7a9; border-color:#2bb7a9; background:#fff; }
-.oauth-btn--google:hover{ background:#f8fffd; transform:translateY(-1px); box-shadow:0 12px 28px rgba(43,212,195,.20); }
-.oauth-btn--google:active{ transform:translateY(0); box-shadow:0 8px 18px rgba(43,212,195,.16); }
-.oauth-btn--google:focus-visible{ outline:3px solid rgba(73,216,183,.35); outline-offset:2px; }
 
+/* Google ボタン */
+.oauth-btn--google{
+  color:#2bb7a9;
+  border-color:#2bb7a9;
+  background:#fff;
+}
+.oauth-btn--google:hover{
+  background:#f8fffd;
+  transform:translateY(-1px);
+  box-shadow:0 12px 28px rgba(43,212,195,.20);
+}
+.oauth-btn--google:active{
+  transform:translateY(0);
+  box-shadow:0 8px 18px rgba(43,212,195,.16);
+}
+.oauth-btn--google:focus-visible{
+  outline:3px solid rgba(73,216,183,.35);
+  outline-offset:2px;
+}
+
+/* Google ボタン（枠線なし・今のログイン画面用） */
 .oauth-btn--google.oauth-btn--borderless{
-  border-color:transparent; background:transparent; color:#2bb7a9; box-shadow:0 6px 16px rgba(0,0,0,.04);
+  border-color:transparent;
+  background:transparent;
+  color:#2bb7a9;
+  box-shadow:0 6px 16px rgba(0,0,0,.04);
 }
 .oauth-btn--google.oauth-btn--borderless:hover{
-  background:rgba(43,212,195,.06); transform:translateY(-1px); box-shadow:0 10px 22px rgba(43,212,195,.16);
+  background:rgba(43,212,195,.06);
+  transform:translateY(-1px);
+  box-shadow:0 10px 22px rgba(43,212,195,.16);
 }
-.oauth-btn--google.oauth-btn--borderless:active{ transform:none; box-shadow:0 6px 14px rgba(43,212,195,.12); }
+.oauth-btn--google.oauth-btn--borderless:active{
+  transform:none;
+  box-shadow:0 6px 14px rgba(43,212,195,.12);
+}
 
-.oauth-btn__icon{ display:inline-flex; width:18px; height:18px; flex:0 0 18px; }
-.oauth-btn__label{ font-size:15px; font-weight:500; }
+/* LINE ボタン：文字色を Google と同じミント色に統一 */
+.oauth-btn--line{
+  color:#2bb7a9;
+}
+.oauth-btn--line .oauth-btn__label{
+  color:inherit;
+}
 
-.oauth-btn:disabled{ opacity:.6; cursor:not-allowed; transform:none; box-shadow:0 0 0 rgba(0,0,0,0); }
+/* アイコン & ラベル */
+.oauth-btn__icon{
+  display:inline-flex;
+  width:18px;
+  height:18px;
+  flex:0 0 18px;
+}
+.oauth-btn__label{
+  font-size:15px;
+  font-weight:500;
+  color:inherit; /* ボタン側の color をそのまま使う */
+}
 
+/* 無効状態 */
+.oauth-btn:disabled{
+  opacity:.6;
+  cursor:not-allowed;
+  transform:none;
+  box-shadow:0 0 0 rgba(0,0,0,0);
+}
+
+/* アニメーション減らす設定の人向け */
 @media (prefers-reduced-motion: reduce){
   .oauth-btn{ transition:none; }
-  .oauth-btn:hover, .oauth-btn:active{ transform:none; box-shadow:0 10px 24px rgba(0,0,0,.05); }
+  .oauth-btn:hover,
+  .oauth-btn:active{
+    transform:none;
+    box-shadow:0 10px 24px rgba(0,0,0,.05);
+  }
 }
+
+/* スマホ幅調整 */
 @media (max-width:420px){
   .devise-oauth{ padding-inline:0; }
-  .oauth-btn{ width:100%; justify-content:center; }
+  .oauth-btn{
+    width:100%;
+    justify-content:center;
+  }
 }
+
+/* ヒーロー周りの微調整（既存） */
 @media (max-width:380px){
   body.landing-root .hero__inner{ --stack-gap: 12px; }
   body.landing-root .hero__cta{ margin-top: 16px; }

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -30,44 +30,74 @@
         <%= render "shared/lp_effects" %>
       </div>
 
-      <%# ▼ アカウント操作：SP=「新規登録/ログイン」横並び2列＋その下にGoogle / PC=3つ横並び %>
+      <%# ▼ アカウント操作
+          1段目: 新規登録 / ログイン
+          2段目: Googleでログイン / LINEでログイン %>
       <div class="mt-6 md:mt-8 w-full">
-        <div class="grid grid-cols-2 gap-3
-                    sm:flex sm:flex-row sm:flex-nowrap sm:items-center sm:justify-center sm:gap-3">
+        <div class="flex flex-col items-center gap-3 sm:gap-4">
 
-          <!-- 新規登録 -->
-          <%= link_to new_user_registration_path,
-                class: "btn-mint w-full inline-flex items-center justify-center rounded-xl px-6 py-3 text-[15px] font-semibold
-                        focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-emerald-400 sm:w-auto" do %>
-            新規登録
-          <% end %>
+          <!-- 1段目: 新規登録 / ログイン -->
+          <div class="flex flex-wrap gap-3 justify-center">
+            <!-- 新規登録 -->
+            <%= link_to new_user_registration_path,
+                  class: "inline-flex items-center justify-center rounded-xl px-6 py-3 text-[15px] font-semibold
+                          btn-mint
+                          focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-emerald-400" do %>
+              新規登録
+            <% end %>
 
-          <!-- ログイン -->
-          <%= link_to new_user_session_path,
-                class: "w-full inline-flex items-center justify-center rounded-xl px-6 py-3 text-[15px] font-semibold
-                        bg-white text-emerald-400 ring-1 ring-emerald-300 hover:bg-white/90 shadow-sm
-                        focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-emerald-300 sm:w-auto" do %>
-            ログイン
-          <% end %>
+            <!-- ログイン -->
+            <%= link_to new_user_session_path,
+                  class: "inline-flex items-center justify-center rounded-xl px-6 py-3 text-[15px] font-semibold
+                          bg-white text-emerald-400 ring-1 ring-emerald-300 hover:bg-white/90 shadow-sm
+                          focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-emerald-300" do %>
+              ログイン
+            <% end %>
+          </div>
 
-          <!-- Googleでログイン（SPは下段フル幅／PCは横並びで自動幅） -->
-          <%= button_to user_google_oauth2_omniauth_authorize_path,
-                method: :post,
-                form:  { class: "col-span-2 flex justify-center", data: { turbo: false } },
-                class: "w-full sm:w-auto inline-flex items-center justify-center gap-2 rounded-xl px-6 py-3 text-[15px] font-semibold
-                        bg-white text-emerald-400 ring-1 ring-emerald-300 hover:bg-white/90 shadow-sm
-                        focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-emerald-300",
-                aria:  { label: "Googleでログイン" } do %>
-            <span class="inline-flex -ml-0.5" aria-hidden="true">
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 262" width="18" height="18" role="img" focusable="false">
-                <path fill="#4285F4" d="M255.68 133.5c0-10.7-.86-18.5-2.72-26.6H130.55v48.2h71.72c-1.45 12-9.3 30-26.8 42.2l-.24 1.6 38.9 30 .27.3c25.37-23.4 40.37-57.8 40.37-96.9Z"/>
-                <path fill="#34A853" d="M130.55 261.1c36.7 0 67.46-12.1 89.96-32.9l-42.9-33.1c-11.5 8.1-26.9 13.8-47 13.8-35.9 0-66.3-23.9-77.1-56.9l-1.6.1-41.97 32.5-.55.1c22.45 44.6 68.5 76.5 121.66 76.5Z"/>
-                <path fill="#FBBC05" d="M53.45 151.9c-2.9-8.1-4.6-16.8-4.6-25.9s1.7-17.8 4.6-25.9l-.1-1.7L11.03 65.5l-1.34.6C3.32 79.9 0 96 0 112.9c0 16.9 3.32 33 9.7 46.8l43.75-33.8Z"/>
-                <path fill="#EB4335" d="M130.55 50.2c25.5 0 42.7 11 52.5 20.2l38.3-37.5C197.8 12 167.25 0 130.55 0 77.4 0 31.35 31.9 8.9 76.5l44.45 33.6c10.8-33 41.2-59.9 77.2-59.9Z"/>
-              </svg>
-            </span>
-            <span>Googleでログイン</span>
-          <% end %>
+          <!-- 2段目: Google / LINE ログイン -->
+          <div class="flex flex-wrap gap-3 justify-center">
+            <!-- Googleでログイン -->
+            <%= button_to user_google_oauth2_omniauth_authorize_path,
+                  method: :post,
+                  form:  { data: { turbo: false } },
+                  class: "inline-flex items-center justify-center gap-2 rounded-xl px-6 py-3 text-[15px] font-semibold
+                          bg-white text-emerald-400 ring-1 ring-emerald-300 hover:bg-white/90 shadow-sm
+                          focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-emerald-300",
+                  aria:  { label: "Googleでログイン" } do %>
+              <span class="inline-flex -ml-0.5" aria-hidden="true">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 262" width="18" height="18" role="img" focusable="false">
+                  <path fill="#4285F4" d="M255.68 133.5c0-10.7-.86-18.5-2.72-26.6H130.55v48.2h71.72c-1.45 12-9.3 30-26.8 42.2l-.24 1.6 38.9 30 .27.3c25.37-23.4 40.37-57.8 40.37-96.9Z"/>
+                  <path fill="#34A853" d="M130.55 261.1c36.7 0 67.46-12.1 89.96-32.9l-42.9-33.1c-11.5 8.1-26.9 13.8-47 13.8-35.9 0-66.3-23.9-77.1-56.9l-1.6.1-41.97 32.5-.55.1c22.45 44.6 68.5 76.5 121.66 76.5Z"/>
+                  <path fill="#FBBC05" d="M53.45 151.9c-2.9-8.1-4.6-16.8-4.6-25.9s1.7-17.8 4.6-25.9l-.1-1.7L11.03 65.5l-1.34.6C3.32 79.9 0 96 0 112.9c0 16.9 3.32 33 9.7 46.8l43.75-33.8Z"/>
+                  <path fill="#EB4335" d="M130.55 50.2c25.5 0 42.7 11 52.5 20.2l38.3-37.5C197.8 12 167.25 0 130.55 0 77.4 0 31.35 31.9 8.9 76.5l44.45 33.6c10.8-33 41.2-59.9 77.2-59.9Z"/>
+                </svg>
+              </span>
+              <span>Googleでログイン</span>
+            <% end %>
+
+            <!-- LINEでログイン -->
+            <%= button_to user_line_omniauth_authorize_path,
+                  method: :post,
+                  form:  { data: { turbo: false } },
+                  class: "inline-flex items-center justify-center gap-2 rounded-xl px-6 py-3 text-[15px] font-semibold
+                          bg-white text-emerald-400 ring-1 ring-emerald-300 hover:bg-white/90 shadow-sm
+                          focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-emerald-300",
+                  aria:  { label: "LINEでログイン" } do %>
+              <span class="inline-flex -ml-0.5" aria-hidden="true">
+                <svg width="18" height="18" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg" role="img" focusable="false">
+                  <rect x="0" y="0" width="36" height="36" rx="8" fill="#06C755" />
+                  <text x="18" y="21" text-anchor="middle"
+                        font-size="11"
+                        font-family="system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif"
+                        fill="#FFFFFF">
+                    LINE
+                  </text>
+                </svg>
+              </span>
+              <span>LINEでログイン</span>
+            <% end %>
+          </div>
 
         </div>
       </div>

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -57,23 +57,40 @@
                       class: "oauth-btn oauth-btn--google oauth-btn--borderless",
                       aria: { label: "Googleでログイン" } do %>
           <span class="oauth-btn__icon" aria-hidden="true">
-            <svg width="18" height="18" viewBox="0 0 48 48">
-              <path fill="#FFC107" d="M43.6 20.5H42V20H24v8h11.3C34 32.9 29.5 36 24 36 16.8 36 11 30.2 11 23s5.8-13 13-13c3.1 0 5.9 1.1 8.1 2.9l5.7-5.7C34.2 4.9 29.4 3 24 3 16 3 9.2 7.6 6.3 14.7z"/>
-              <path fill="#FF3D00" d="M6.3 14.7l6.6 4.8C14.5 16 18.9 13 24 13c3.1 0 5.9 1.1 8.1 2.9l5.7-5.7C34.2 4.9 29.4 3 24 3 16 3 9.2 7.6 6.3 14.7z"/>
-              <path fill="#4CAF50" d="M24 45c5.4 0 10.2-1.8 13.6-4.9l-6.3-5.2C29.5 36 26.9 37 24 37c-5.4 0-9.9-3.6-11.4-8.5l-6.5 5C8.9 41.8 15.9 45 24 45z"/>
-              <path fill="#1976D2" d="M43.6 20.5H42V20H24v8h11.3c-1 2.9-3.8 6-7.3 6-5.4 0-9.9-3.6-11.4-8.5l-6.5 5C12 38.7 17.5 43 24 43c10.8 0 20-7.8 20-21 0-1.3-.1-2.2-.4-3.5z"/>
+            <!-- Google 公式 “G” アイコンに近いパス -->
+            <svg width="18" height="18" viewBox="0 0 18 18" xmlns="http://www.w3.org/2000/svg">
+              <path fill="#EA4335" d="M8.999 7.152V10.2h4.284c-.174 1.116-.774 2.061-1.647 2.688l2.664 2.055C15.02 13.494 15.75 11.664 15.75 9.36c0-.498-.045-.975-.129-1.44H8.999z"/>
+              <path fill="#34A853" d="M4.74 10.71a5.36 5.36 0 0 1-.285-1.71c0-.594.105-1.17.285-1.71L2.13 5.085A8.36 8.36 0 0 0 1.5 8.999c0 1.35.327 2.622.63 3.915L4.74 10.71z"/>
+              <path fill="#FBBC05" d="M8.999 4.095c1.17 0 2.214.402 3.039 1.194l2.28-2.28A7.26 7.26 0 0 0 8.999 2.25a7.497 7.497 0 0 0-6.87 4.035L4.74 7.29c.39-1.179 1.47-3.195 4.259-3.195z"/>
+              <path fill="#4285F4" d="M8.999 15.75c1.98 0 3.642-.651 4.884-1.806l-2.664-2.055c-.72.504-1.65.81-2.22.81-2.79 0-3.87-2.016-4.259-3.195l-3.111 2.205A7.492 7.492 0 0 0 8.999 15.75z"/>
             </svg>
           </span>
-          <p class="oauth-btn__label">Googleでログイン</p>
+          <p class="oauth-btn__label" style="color:#18b8a5; font-weight:600;">
+            Googleでログイン
+          </p>
         <% end %>
 
         <!-- LINE ログイン -->
         <%= button_to user_line_omniauth_authorize_path,
                       method: :post,
                       form: { class: "inline", data: { turbo: false } },
-                      class: "oauth-btn oauth-btn--line",
+                      class: "oauth-btn oauth-btn--line oauth-btn--borderless",
                       aria: { label: "LINEでログイン" } do %>
-          <p class="oauth-btn__label">LINEでログイン</p>
+          <span class="oauth-btn__icon" aria-hidden="true">
+            <!-- LINE ロゴ風：グリーンの角丸四角＋「LINE」文字 -->
+            <svg width="18" height="18" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg">
+              <rect x="0" y="0" width="36" height="36" rx="8" fill="#06C755" />
+              <text x="18" y="21" text-anchor="middle"
+                    font-size="11"
+                    font-family="system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial, sans-serif"
+                    fill="#FFFFFF">
+                LINE
+              </text>
+            </svg>
+          </span>
+          <p class="oauth-btn__label" style="color:#18b8a5; font-weight:600;">
+            LINEでログイン
+          </p>
         <% end %>
       </div>
 


### PR DESCRIPTION
## 概要
- LP に「LINEでログイン」ボタンを追加
- ログイン画面の Google / LINE ログインボタンのデザイン調整
- 各ボタンのレイアウトを PC / SP 共通で
  - 1段目: 新規登録 / ログイン
  - 2段目: Googleでログイン / LINEでログイン
  に統一

## 変更内容
- `app/views/pages/home.html.erb`
  - LP に LINE ログインボタンを追加
  - 各ボタンのレイアウトを2段構成に変更
- `app/views/users/sessions/new.html.erb`
  - LINE 公式ロゴ風アイコンを追加
  - Google/LINE のラベルカラーを Fasty ミントで統一
- `devise.css`, `landing.css`
  - OAuth ボタンの共通スタイルを調整

## 動作確認
- [x] ログイン画面で Google / LINE ログインボタンが正しく表示される
- [x] LP で
  - 1段目: 新規登録 / ログイン
  - 2段目: Googleでログイン / LINEでログイン
  が PC / スマホともに意図したレイアウトで表示される

Closes #169
