### PR TITLE
AI食事提案: 直近履歴を考慮してメニューのバリエーションを強化 (#207)

### DIFF
--- a/app/services/meal_suggestions/generator.rb
+++ b/app/services/meal_suggestions/generator.rb
@@ -120,17 +120,17 @@ module MealSuggestions
 
     def build_user_prompt(insight, phase, recent_menus, current_menu)
       phase_hint = case phase
-                   when "fasting_now"
+      when "fasting_now"
                      "ユーザーは現在も断食中です。水分補給や、断食終了後1〜2食目のイメージを伝えてください。"
-                   when "recovery_day1"
+      when "recovery_day1"
                      "断食終了から1日以内の「回復食1日目」です。かなりやさしいメニューにしてください。"
-                   when "recovery_day2"
+      when "recovery_day2"
                      "回復食2日目です。まだ消化にやさしいものを中心にしつつ、少しずつ固形物を増やしてよい段階です。"
-                   when "recovery_day3_plus"
+      when "recovery_day3_plus"
                      "回復食3日目以降です。通常食に近づけつつも、揚げ物や脂っこいもの・お酒は控えめにしてください。"
-                   else
+      else
                      "最近の記録を参考にしつつ、無理のないバランスのよい1日分のメニューを提案してください。"
-                   end
+      end
 
       recent_text =
         if recent_menus.present?


### PR DESCRIPTION
## 概要

Issue #207 の対応として、AI食事コンシェルジュが提案する
1日の食事メニューについて、**直近の提案履歴を考慮してバリエーションを増やす**ようにしました。

テンプレ感のあるメニュー提案にならないよう、
ユーザーごとの履歴を踏まえて「毎回ちゃんと違うメニュー」を目指します。

Refs: #207

---

## 変更内容

### 1. 直近のメニュー履歴をプロンプトに含めるように変更

`app/services/meal_suggestions/generator.rb`

- 直近 **7日分** の MealSuggestion を取得するメソッドを追加

  ```ruby
  recent_menu_history
